### PR TITLE
fix: remove --no-scripts from composer install in deployment

### DIFF
--- a/.github/README-DEPLOYMENT.md
+++ b/.github/README-DEPLOYMENT.md
@@ -52,12 +52,13 @@ Le déploiement se déclenche automatiquement :
 2. 📁 Navigation vers `/var/www/html/gnut06_dev`
 3. 📥 `git pull` des dernières modifications
 4. 📁 Navigation vers le sous-dossier `app`
-5. 📦 `composer install` (dépendances PHP)
-6. 🗄️ Migrations de base de données
-7. 📦 `npm install` (dépendances Node.js)
-8. 🎨 `npm run build` (compilation des assets)
-9. 🧹 Vidage du cache Symfony
-10. 🔥 Réchauffement du cache
+5. 📦 `composer install --no-dev --no-scripts` (dépendances PHP production)
+6. 🔄 Optimisation de l'autoloader pour la production
+7. 🗄️ Migrations de base de données (env: prod)
+8. 📦 `npm install --production` (dépendances Node.js)
+9. 🎨 `npm run build` (compilation des assets)
+10. 🧹 Vidage du cache Symfony (env: prod)
+11. 🔥 Réchauffement du cache (env: prod)
 
 ## Prérequis sur le serveur
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -71,9 +71,13 @@ jobs:
             echo "📦 Installing/updating PHP dependencies..."
             composer install --no-dev --optimize-autoloader
             
+            # Régénérer l'autoloader après suppression des packages dev
+            echo "🔄 Optimizing autoloader for production..."
+            composer dump-autoload --optimize --classmap-authoritative
+            
             # Exécuter les migrations
             echo "🗄️ Running database migrations..."
-            php bin/console doctrine:migrations:migrate --no-interaction
+            php bin/console doctrine:migrations:migrate --no-interaction --env=prod
             
             # Installer/mettre à jour les dépendances Node.js
             echo "📦 Installing/updating Node.js dependencies..."
@@ -85,11 +89,11 @@ jobs:
             
             # Vider le cache Symfony
             echo "🧹 Clearing Symfony cache..."
-            sudo -u www-data php bin/console cache:clear --env=prod
+            sudo -u www-data php bin/console cache:clear --env=prod --no-debug
             
             # Réchauffer le cache
             echo "🔥 Warming up cache..."
-            sudo -u www-data php bin/console cache:warmup --env=prod
+            sudo -u www-data php bin/console cache:warmup --env=prod --no-debug
             
             echo "✅ Deployment completed successfully!"
         env:


### PR DESCRIPTION
- Allow post-install scripts to run during composer install
- Ensure proper bundle configuration after dependency installation
- Maintain production environment with optimized autoloader