### PR TITLE
fix: install all npm dependencies for Webpack Encore build

### DIFF
--- a/.github/README-DEPLOYMENT.md
+++ b/.github/README-DEPLOYMENT.md
@@ -52,11 +52,11 @@ Le déploiement se déclenche automatiquement :
 2. 📁 Navigation vers `/var/www/html/gnut06_dev`
 3. 📥 `git pull` des dernières modifications
 4. 📁 Navigation vers le sous-dossier `app`
-5. 📦 `composer install --no-dev --no-scripts` (dépendances PHP production)
+5. 📦 `composer install --no-dev` (dépendances PHP production)
 6. 🔄 Optimisation de l'autoloader pour la production
 7. 🗄️ Migrations de base de données (env: prod)
-8. 📦 `npm install --production` (dépendances Node.js)
-9. 🎨 `npm run build` (compilation des assets)
+8. 📦 `npm install` (toutes les dépendances Node.js, y compris dev pour Encore)
+9. 🎨 `npm run build` (compilation des assets via Webpack Encore)
 10. 🧹 Vidage du cache Symfony (env: prod)
 11. 🔥 Réchauffement du cache (env: prod)
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -81,7 +81,7 @@ jobs:
             
             # Installer/mettre à jour les dépendances Node.js
             echo "📦 Installing/updating Node.js dependencies..."
-            npm install --production
+            npm install
             
             # Générer les assets
             echo "🎨 Building assets..."


### PR DESCRIPTION
- Change npm install from --production to full install
- Include dev dependencies required for Webpack Encore compilation
- Fix 'encore: not found' error during asset build
- Update deployment documentation to reflect correct npm install