### PR TITLE
fix: add permission fix for Symfony cache directory

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -89,6 +89,7 @@ jobs:
             
             # Vider le cache Symfony
             echo "🧹 Clearing Symfony cache..."
+            sudo chown -R www-data:www-data /var/www/html/gnut06_dev/app/var
             sudo -u www-data php bin/console cache:clear --env=prod --no-debug
             
             # Réchauffer le cache


### PR DESCRIPTION
- Add sudo chown command to fix var directory permissions
- Ensure www-data owns cache directory before cache operations
- Resolve 'Unable to write in cache/prod directory' error
- Complete functional deployment pipeline