### PR TITLE
Fix TIH map coordinates payload and AdvancedMarker cleanup

### DIFF
--- a/app/assets/controllers/tih-search_controller.js
+++ b/app/assets/controllers/tih-search_controller.js
@@ -298,6 +298,11 @@ export default class extends Controller {
             if (newProfilesJson) {
                 try {
                     this.profilesValue = JSON.parse(newProfilesJson);
+                    const newCityCoordinatesJson = newMain.getAttribute('data-tih-search-city-coordinates-value');
+                    if (newCityCoordinatesJson) {
+                        const parsedCityCoordinates = JSON.parse(newCityCoordinatesJson);
+                        this.cityCoordinatesValue = Array.isArray(parsedCityCoordinates) ? {} : parsedCityCoordinates;
+                    }
                     // Refresh map if it's currently visible
                     if (this.hasMapViewTarget && !this.mapViewTarget.classList.contains('d-none')) {
                         this.initializeMap();
@@ -376,7 +381,10 @@ export default class extends Controller {
         }
 
         // Clear existing markers and info windows
-        this.markers.forEach(marker => marker.setMap(null));
+        this.markers.forEach(marker => {
+            // AdvancedMarkerElement is removed from the map by clearing its map property.
+            marker.map = null;
+        });
         this.infoWindows.forEach(infoWindow => infoWindow.close());
         this.markers = [];
         this.infoWindows = [];

--- a/app/templates/tih_search/index.html.twig
+++ b/app/templates/tih_search/index.html.twig
@@ -24,7 +24,7 @@
         'availabilityDate': profile.availabilityDate ? profile.availabilityDate|date('Y-m-d') : null
       })|json_encode|e('html_attr') }}"
       data-tih-search-api-key-value="{{ googleMapsApiKey }}"
-      data-tih-search-city-coordinates-value="{{ cityCoordinates|json_encode|e('html_attr') }}"
+      data-tih-search-city-coordinates-value="{{ cityCoordinates|json_encode(constant('JSON_FORCE_OBJECT'))|e('html_attr') }}"
       data-action="popstate@window->tih-search&#35;handleBrowserNavigation">
     <div class="container-fluid">
         <header class="text-center mb-5">


### PR DESCRIPTION
### Motivation
- The Stimulus controller expected `cityCoordinates` to be an object but could receive an empty array, causing `TypeError` when initializing the Google map markers. 
- AJAX updates did refresh profile data but did not refresh the associated city coordinates sent in the page payload, leading to stale or missing map markers after filtering/pagination. 
- Google Maps `AdvancedMarkerElement` instances were not being removed correctly which could leave markers attached and cause redraw issues. 

### Description
- Render `cityCoordinates` in the Twig template using `json_encode(constant('JSON_FORCE_OBJECT'))` so an empty object `{}` is emitted instead of `[]`. 
- When updating results via AJAX, parse and assign the `data-tih-search-city-coordinates-value` attribute alongside `profiles` so `cityCoordinatesValue` is refreshed before reinitializing the map. 
- Clear `AdvancedMarkerElement` markers by unsetting their `map` property (`marker.map = null`) instead of calling `setMap(null)` to properly detach them. 
- Small defensive checks and console warnings remain in place to surface missing coordinates. 

### Testing
- Ran `npm run build` which completed successfully and produced compiled assets in `app/public/build`. 
- Executed `node --check assets/controllers/tih-search_controller.js` which returned no syntax errors. 
- Ran `git diff --check` (static diff check) with no issues reported. 
- Attempted `composer install` and `php bin/console lint:twig` but they could not run successfully in this environment due to Composer dependency constraints against the local PHP `8.5.7-dev` snapshot, so PHP/Twig linting was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a240dcc2fac8321a6e607c11612fbb4)