### PR TITLE
Fix dev deployment branch sync

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -159,9 +159,10 @@ jobs:
             else
               git fetch origin "$DEPLOY_BRANCH"
             fi
-            git checkout "$DEPLOY_BRANCH"
-            git pull --ff-only origin "$DEPLOY_BRANCH"
-            echo "🌿 Deploying branch: $DEPLOY_BRANCH"
+            echo "🔄 Aligning local checkout with origin/${DEPLOY_BRANCH}..."
+            git reset --hard "origin/${DEPLOY_BRANCH}"
+            git checkout -B "$DEPLOY_BRANCH" "origin/${DEPLOY_BRANCH}"
+            echo "🌿 Deploying branch: $DEPLOY_BRANCH at $(git rev-parse --short HEAD)"
 
             # Aller dans le dossier app
             cd "$APP_DIR"


### PR DESCRIPTION
### Motivation
- The dev deployment failed when the server working tree had diverged from `origin/develop`, causing `git pull --ff-only` to abort. 
- The workflow needs a deterministic way to align the server checkout with the remote before building and deploying.

### Description
- Update the dev deployment workflow at `..github/workflows/deploy-dev.yml` to stop using `git checkout` + `git pull --ff-only` and instead fetch and forcibly align the working tree. 
- Replace the pull step with `git reset --hard "origin/${DEPLOY_BRANCH}"` and `git checkout -B "$DEPLOY_BRANCH" "origin/${DEPLOY_BRANCH}"`. 
- Log the deployed commit short SHA with `git rev-parse --short HEAD` to make the deployed revision explicit.

### Testing
- Loaded the modified workflow with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-dev.yml"); puts "YAML OK"'` and it returned success. 
- Ran `git diff --check` to validate whitespace/format issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a281dc195988321b1222700dc2bd044)