### PR TITLE
Add TIH search callout to Handi-3D page

### DIFF
--- a/app/templates/hand_3d/index.html.twig
+++ b/app/templates/hand_3d/index.html.twig
@@ -161,6 +161,35 @@
 		        </div>
 		    </section> #}
 
+		<section class="container my-5" aria-labelledby="tih-search-launch-title">
+			<div class="feature-card bg-dark-section">
+				<div class="row align-items-center g-4">
+					<div class="col-lg-8">
+						<p class="text-uppercase fw-bold mb-2 text-white-force">Annuaire TIH Gnut 06</p>
+						<h2 id="tih-search-launch-title" class="h1 text-white-force mb-3">
+							Interface de recherche de TIH de Gnut 06
+						</h2>
+						<p class="lead text-white-force mb-3">
+							Gnut 06 prépare son interface de recherche dédiée aux Travailleurs Indépendants Handicapés (TIH). Vous pouvez déjà découvrir la version actuellement en ligne, alimentée avec des profils TIH fictifs pour présenter le fonctionnement de la plateforme.
+						</p>
+						<p class="text-white-force mb-0">
+							Les TIH qui souhaitent apparaître dans cette plateforme lors de sa sortie prévue en septembre 2026 peuvent se préinscrire dès maintenant en créant leur compte et en cochant la case
+							<strong>« Je m'inscris en tant que Travailleur Indépendant Handicapé (TIH) »</strong>.
+						</p>
+					</div>
+					<div class="col-lg-4 text-center">
+						<a href="{{ path('app_tih_search') }}" class="btn-3d btn-outline-gradient text-white d-block mb-3" role="button" aria-label="Accéder à l'interface de recherche de TIH de Gnut 06">
+							🔎 Découvrir la recherche TIH
+						</a>
+						<a href="{{ path('app_register') }}" class="btn-3d btn-outline-gradient text-white d-block" role="button" aria-label="Se préinscrire comme TIH pour la sortie de septembre 2026">
+							📝 Se préinscrire comme TIH
+						</a>
+					</div>
+				</div>
+			</div>
+		</section>
+
+
 		<!-- Focus 2026 Section -->
 			<section class="container my-5"> <div class="row">
 				<div class="col-12">


### PR DESCRIPTION
### Motivation
- Rendre visible depuis la page Handi-3D l’interface de recherche des Travailleurs Indépendants Handicapés (TIH) de Gnut 06 et informer que les profils actuellement affichés sont fictifs.
- Permettre aux TIH de se préinscrire dès maintenant pour apparaître sur la plateforme lors de sa mise en ligne prévue en septembre 2026 via la page d’inscription.

### Description
- Ajout d’un encart d’information dans `app/templates/hand_3d/index.html.twig` présentant l’« Annuaire TIH Gnut 06 » avec titre et texte explicatif.
- Ajout de deux boutons ciblés qui pointent vers les routes `app_tih_search` (accéder à la recherche TIH) et `app_register` (préinscription TIH) avec attributs `aria-label` pour l’accessibilité.
- L’encart réutilise les classes de style existantes (`feature-card`, `bg-dark-section`, `btn-3d`, etc.) et explique que les profils en ligne sont fictifs tout en demandant aux TIH de cocher la case « Je m'inscris en tant que Travailleur Indépendant Handicapé (TIH) » lors de l’inscription.

### Testing
- `php -l app/templates/hand_3d/index.html.twig` — succès (aucune erreur de syntaxe détectée).
- `git diff --check` — succès (aucun avertissement signalé).
- `cd app && php bin/console lint:twig templates/hand_3d/index.html.twig` — non exécuté en local car les dépendances Symfony sont manquantes; `composer install` est requis pour lancer cette vérification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3001bff1508321b00218fe486452f3)