### PR TITLE
fix: avoid missing images copy warning

### DIFF
--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -1,4 +1,5 @@
 const Encore = require('@symfony/webpack-encore');
+const fs = require('fs');
 const webpack = require('webpack');
 
 // Manually configure the runtime environment if not already configured yet by the "encore" command.
@@ -15,12 +16,6 @@ Encore
 .setPublicPath('/build')
 // only needed for CDN's or subdirectory deploy
     //.setManifestKeyPrefix('build/')
-    .copyFiles({
-      from: './assets/styles/images',
-      to: 'images/[path][name].[ext]',
-      pattern: /\.(png|jpg|jpeg)$/
-      
-    })
     /*
     * ENTRY CONFIG
     *
@@ -92,5 +87,15 @@ Encore
       }))
   
   ;
+
+const imagesPath = './assets/styles/images';
+
+if (fs.existsSync(imagesPath)) {
+    Encore.copyFiles({
+        from: imagesPath,
+        to: 'images/[path][name].[ext]',
+        pattern: /\.(png|jpg|jpeg)$/,
+    });
+}
   
   module.exports = Encore.getWebpackConfig();


### PR DESCRIPTION
### Motivation
- Prevent webpack from emitting a warning when the configured images source directory does not exist by guarding the copy step.

### Description
- Add `const fs = require('fs')` and wrap the `Encore.copyFiles(...)` call in `app/webpack.config.js` with an `if (fs.existsSync('./assets/styles/images')) { ... }` check so the copy is only configured when the directory exists.

### Testing
- Ran `cd app && npm run build` which compiled successfully, ran `git diff --check` with no issues, ran `composer validate --no-check-publish` (reported existing `composer.lock` mismatch warnings), attempted `composer install --no-interaction` (failed due to PHP platform/version constraint in this environment), and ran PHP linting with `find src tests -name '*.php' -print0 | xargs -0 -n1 php -l` which reported no syntax errors for the files checked before the run was interrupted by the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36889a287c8321bdba780e8a6356ee)