### PR TITLE
Secure OAuth account linking (Google & Microsoft)

### DIFF
--- a/app/migrations/Version20260621120000.php
+++ b/app/migrations/Version20260621120000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260621120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique indexes for OAuth provider identifiers.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_USER_GOOGLE_ID ON user (google_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_USER_AZURE_ID ON user (azure_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_USER_GOOGLE_ID ON user');
+        $this->addSql('DROP INDEX UNIQ_USER_AZURE_ID ON user');
+    }
+}

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -14,6 +14,8 @@ use Symfony\Component\Validator\Constraints\PasswordStrength;
 
 #[ORM\Entity(repositoryClass: UserRepository::class)]
 #[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]
+#[ORM\UniqueConstraint(name: 'UNIQ_USER_GOOGLE_ID', fields: ['googleId'])]
+#[ORM\UniqueConstraint(name: 'UNIQ_USER_AZURE_ID', fields: ['azureId'])]
 #[UniqueEntity(fields: ['email'], message: 'Il existe déjà un compte avec cet email')]
 #[ORM\HasLifecycleCallbacks]
 class User implements UserInterface, PasswordAuthenticatedUserInterface

--- a/app/src/Security/GoogleAuthenticator.php
+++ b/app/src/Security/GoogleAuthenticator.php
@@ -2,11 +2,14 @@
 
 namespace App\Security;
 
-use App\Entity\User; // Assurez-vous que le chemin vers votre entité User est correct
+use App\Entity\User;
+use App\Service\EmailService;
 use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use League\OAuth2\Client\Provider\GoogleUser;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,170 +21,118 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
-use App\Service\EmailService;
-use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\Routing\Annotation\Route;
-use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
-class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationEntrypointInterface
+class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
-    private ClientRegistry $clientRegistry;
-    private EntityManagerInterface $entityManager;
-    private RouterInterface $router;
-    private UserPasswordHasherInterface $passwordHasher;
-    private EmailService $emailService;
-    private LoggerInterface $logger;
-    private Security $security;
-    private SessionInterface $session;
-  
-    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher, EmailService $emailService, LoggerInterface $logger, Security $security, RequestStack $requestStack)
-    {
-        $this->clientRegistry = $clientRegistry;
-        $this->entityManager = $entityManager;
-        $this->router = $router;
-        $this->passwordHasher = $passwordHasher;
-        $this->emailService = $emailService;
-        $this->logger = $logger;
-        $this->security = $security;
-        $this->session = $requestStack->getSession();
-       
+    private bool $oauthLinking = false;
+
+    public function __construct(
+        private readonly ClientRegistry $clientRegistry,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly RouterInterface $router,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly EmailService $emailService,
+        private readonly LoggerInterface $logger,
+        private readonly Security $security,
+    ) {
     }
 
-    /**
-     * Détermine si cet authentificateur doit être utilisé pour la requête actuelle.
-     * Il ne s'active que sur la route de callback de Google.
-     */
     public function supports(Request $request): ?bool
     {
         return $request->attributes->get('_route') === 'connect_google_check';
     }
 
-    /**
-     * C'est ici que la logique d'authentification principale a lieu.
-     */
     public function authenticate(Request $request): Passport
     {
-        // Récupère le client OAuth2 'google' que nous avons configuré
         $client = $this->clientRegistry->getClient('google');
-        // Récupère le jeton d'accès depuis la requête
         $accessToken = $this->fetchAccessToken($client);
 
         return new SelfValidatingPassport(
-            new UserBadge($accessToken->getToken(), function () use ($accessToken, $client) {
+            new UserBadge($accessToken->getToken(), function () use ($accessToken, $client): User {
                 /** @var GoogleUser $googleUser */
                 $googleUser = $client->fetchUserFromToken($accessToken);
 
                 $email = $googleUser->getEmail();
                 $googleId = $googleUser->getId();
 
-                // 1. Cherche un utilisateur correspondant à ce googleId d'abord
-                $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['googleId' => $googleId]);
-
-                if ($existingUser) {
-                    // L'utilisateur existe déjà avec ce Google ID, on le retourne
-                    return $existingUser;
+                if (!$email || !$googleId) {
+                    throw new AuthenticationException('Google n\'a pas transmis les informations nécessaires au compte.');
                 }
 
-                // 2. Cherche un utilisateur correspondant à cet e-mail dans notre base de données
+                $linkedUser = $this->entityManager->getRepository(User::class)->findOneBy(['googleId' => $googleId]);
+                $currentUser = $this->security->getUser();
+
+                if ($currentUser instanceof User) {
+                    if ($linkedUser && $linkedUser->getId() !== $currentUser->getId()) {
+                        throw new AuthenticationException('Ce compte Google est déjà lié à un autre utilisateur.');
+                    }
+
+                    if ($currentUser->getGoogleId() && $currentUser->getGoogleId() !== $googleId) {
+                        throw new AuthenticationException('Votre profil est déjà lié à un autre compte Google.');
+                    }
+
+                    $currentUser->setGoogleId($googleId);
+                    $this->entityManager->flush();
+                    $this->oauthLinking = true;
+
+                    return $currentUser;
+                }
+
+                if ($linkedUser) {
+                    return $linkedUser;
+                }
+
                 $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
 
                 if ($existingUser) {
-                    // L'utilisateur existe avec cet email, on lie le compte Google
-                    $existingUser->setGoogleId($googleId);
-                    $this->entityManager->persist($existingUser);
-                    $this->entityManager->flush();
-                    return $existingUser;
+                    throw new AuthenticationException('Un compte existe déjà avec cet email. Connectez-vous avec votre mot de passe, puis liez Google depuis votre profil.');
                 }
 
-                // 3. L'utilisateur n'existe pas, on le crée et on l'enregistre
                 $newUser = new User();
                 $newUser->setEmail($email);
                 $newUser->setGoogleId($googleId);
-                
-                // Le mot de passe n'est pas nécessaire pour une connexion sociale,
-                // mais notre entité User en requiert un. On lui assigne donc
-                // une longue chaîne de caractères aléatoire et sécurisée.
-                $hashedPassword = $this->passwordHasher->hashPassword(
-                    $newUser,
-                    bin2hex(random_bytes(32))
-                );
-                $newUser->setPassword($hashedPassword);
-                
-                // Vous pouvez définir d'autres propriétés ici
-                // Par exemple, si vous avez une propriété `fullName` :
-                // $newUser->setFullName($googleUser->getName());
-                // Ou pour les rôles :
-                // $newUser->setRoles(['ROLE_USER']);
+                $newUser->setRoles(['ROLE_USER']);
+                $newUser->setPassword($this->passwordHasher->hashPassword($newUser, bin2hex(random_bytes(32))));
+
+                $googleData = $googleUser->toArray();
+                $newUser->setVerified(($googleData['email_verified'] ?? false) === true);
 
                 $this->entityManager->persist($newUser);
                 $this->entityManager->flush();
 
-                if ($newUser) {
-            // Si l'utilisateur n'est pas encore vérifié, on envoie l'email de confirmation
-             try {
-                $this->emailService->sendConfirmationEmail($newUser);
-               // $this->addFlash('success', 'Un email de confirmation a été envoyé. Veuillez consulter votre boîte mail.');
-            } catch (\Exception $e) {
-                $this->logger->error('Erreur envoi email de confirmation', ['exception' => $e]);
-               // $this->addFlash('danger', 'Problème lors de l\'envoi du mail. Veuillez réessayer.');
-            }
-           // return $this->redirectToRoute('app_profil');
-            return $this->security->login($newUser, 'form_login', 'main');; // Retourne l'utilisateur connecté.
-        }
-        else{
-          //  $this->addFlash('danger', "Erreur lors de l'authentification Google. Veuillez réessayer ou contacter l'administrateur.");
-           // return $this->redirectToRoute('app_login');
-        }
+                if (!$newUser->isVerified()) {
+                    try {
+                        $this->emailService->sendConfirmationEmail($newUser);
+                    } catch (\Exception $e) {
+                        $this->logger->error('Erreur envoi email de confirmation', ['exception' => $e]);
+                    }
+                }
 
-              //  return $this->redirectToRoute('app_profil');
+                return $newUser;
             })
         );
     }
 
-    /**
-     * Appelé lorsque l'authentification réussit.
-     * Redirige l'utilisateur vers la page d'accueil.
-     */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        // Changez 'app_home' pour le nom de la route vers laquelle vous voulez rediriger
-        $targetUrl = $this->router->generate('app_profil');
+        if ($this->oauthLinking) {
+            $request->getSession()->getFlashBag()->add('success', 'Votre compte Google est lié à votre profil.');
+        }
 
-        return new RedirectResponse($targetUrl);
+        return new RedirectResponse($this->router->generate('app_profil'));
     }
 
-    /**
-     * Appelé lorsque l'authentification échoue.
-     */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        $message = strtr($exception->getMessageKey(), $exception->getMessageData());
+        if ($request->hasSession()) {
+            $request->getSession()->getFlashBag()->add('danger', $exception->getMessage());
+        }
 
-        // Vous pouvez rediriger vers la page de connexion avec un message d'erreur
-       // $request->getSession()-> $this->addFlash('danger', $message);
-        
-        return new RedirectResponse(
-            $this->router->generate('app_profil')
-        );
-    }
-     public function __toString(): string
-    {
-        return self::class;
+        return new RedirectResponse($this->router->generate('app_login'));
     }
 
-    /**
-     * Cette méthode est appelée lorsque l'utilisateur essaie d'accéder à une ressource
-     * sécurisée sans être authentifié. Elle le redirige vers le processus de connexion Google.
-     */
     public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
-        return new RedirectResponse(
-            $this->router->generate('connect_google_start'),
-            Response::HTTP_TEMPORARY_REDIRECT
-        );
+        return new RedirectResponse($this->router->generate('connect_google_start'), Response::HTTP_TEMPORARY_REDIRECT);
     }
 }

--- a/app/src/Security/OutlookAuthenticator.php
+++ b/app/src/Security/OutlookAuthenticator.php
@@ -9,6 +9,7 @@ use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -25,13 +26,16 @@ class OutlookAuthenticator extends OAuth2Authenticator implements Authentication
     private EntityManagerInterface $entityManager;
     private RouterInterface $router;
     private UserPasswordHasherInterface $passwordHasher;
+    private Security $security;
+    private bool $oauthLinking = false;
 
-    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher)
+    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher, Security $security)
     {
         $this->clientRegistry = $clientRegistry;
         $this->entityManager = $entityManager;
         $this->router = $router;
         $this->passwordHasher = $passwordHasher;
+        $this->security = $security;
     }
 
     public function supports(Request $request): ?bool
@@ -69,33 +73,40 @@ class OutlookAuthenticator extends OAuth2Authenticator implements Authentication
                 throw new AuthenticationException('Impossible de récupérer l\'email depuis Microsoft Azure. Données reçues: ' . json_encode(array_keys($azureData)));
             }
 
-            // Chercher l'utilisateur par azureId d'abord, puis par email
             $user = $this->entityManager->getRepository(User::class)
                 ->findOneBy(['azureId' => $azureId]);
+            $currentUser = $this->security->getUser();
 
-            if (!$user) {
-                // Vérifier si un utilisateur avec cet email existe déjà
-                $user = $this->entityManager->getRepository(User::class)
+            if ($currentUser instanceof User) {
+                if ($user && $user->getId() !== $currentUser->getId()) {
+                    throw new AuthenticationException('Ce compte Microsoft est déjà lié à un autre utilisateur.');
+                }
+
+                if ($currentUser->getAzureId() && $currentUser->getAzureId() !== $azureId) {
+                    throw new AuthenticationException('Votre profil est déjà lié à un autre compte Microsoft.');
+                }
+
+                $currentUser->setAzureId($azureId);
+                $this->entityManager->flush();
+                $this->oauthLinking = true;
+                $user = $currentUser;
+            } elseif (!$user) {
+                $existingUser = $this->entityManager->getRepository(User::class)
                     ->findOneBy(['email' => $email]);
 
-                if ($user) {
-                    // Lier le compte existant avec Azure
-                    $user->setAzureId($azureId);
-                } else {
-                    // Créer un nouvel utilisateur
-                    $user = new User();
-                    $user->setAzureId($azureId);
-                    $user->setEmail($email);
-                    $user->setRoles(['ROLE_USER']);
-
-                    // Générer un mot de passe aléatoire pour les utilisateurs OAuth
-                    $randomPassword = bin2hex(random_bytes(32));
-                    $hashedPassword = $this->passwordHasher->hashPassword($user, $randomPassword);
-                    $user->setPassword($hashedPassword);
-
-                    // Marquer comme vérifié puisque Microsoft a déjà vérifié l'email
-                    $user->setVerified(true);
+                if ($existingUser) {
+                    throw new AuthenticationException('Un compte existe déjà avec cet email. Connectez-vous avec votre mot de passe, puis liez Microsoft depuis votre profil.');
                 }
+
+                $user = new User();
+                $user->setAzureId($azureId);
+                $user->setEmail($email);
+                $user->setRoles(['ROLE_USER']);
+
+                $randomPassword = bin2hex(random_bytes(32));
+                $hashedPassword = $this->passwordHasher->hashPassword($user, $randomPassword);
+                $user->setPassword($hashedPassword);
+                $user->setVerified(true);
 
                 $this->entityManager->persist($user);
                 $this->entityManager->flush();
@@ -115,6 +126,10 @@ class OutlookAuthenticator extends OAuth2Authenticator implements Authentication
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
+        if ($this->oauthLinking) {
+            $request->getSession()->getFlashBag()->add('success', 'Votre compte Microsoft est lié à votre profil.');
+        }
+
         // Rediriger vers le profil utilisateur après connexion réussie
         $targetUrl = $this->router->generate('app_profil');
         return new RedirectResponse($targetUrl);
@@ -130,7 +145,7 @@ class OutlookAuthenticator extends OAuth2Authenticator implements Authentication
         // Ajouter un message flash pour l'utilisateur
         if ($request->hasSession()) {
             $session = $request->getSession();
-            $session->set('_flash_error', 'Erreur de connexion avec Microsoft: ' . $exception->getMessage());
+            $session->getFlashBag()->add('danger', 'Erreur de connexion avec Microsoft: ' . $exception->getMessage());
         }
 
         return new RedirectResponse($this->router->generate('app_login'));

--- a/app/templates/profil/index.html.twig
+++ b/app/templates/profil/index.html.twig
@@ -196,6 +196,38 @@
                                             <strong>Identifiant :</strong> {{ user.id }}
                                         </p>
 
+                                        <div class="mt-3" aria-labelledby="oauth-links-title">
+                                            <h3 id="oauth-links-title" class="h6 mb-2">Comptes connectés</h3>
+                                            <div class="d-flex flex-column flex-sm-row gap-2">
+                                                {% if user.googleId %}
+                                                    <span class="btn btn-outline-success disabled" aria-disabled="true">
+                                                        <i class="bi bi-google" aria-hidden="true"></i>
+                                                        Google lié
+                                                    </span>
+                                                {% else %}
+                                                    <a href="{{ path('connect_google_start') }}" class="btn btn-outline-primary">
+                                                        <i class="bi bi-google" aria-hidden="true"></i>
+                                                        Lier Google
+                                                    </a>
+                                                {% endif %}
+
+                                                {% if user.azureId %}
+                                                    <span class="btn btn-outline-success disabled" aria-disabled="true">
+                                                        <i class="bi bi-microsoft" aria-hidden="true"></i>
+                                                        Microsoft lié
+                                                    </span>
+                                                {% else %}
+                                                    <a href="{{ path('connect_outlook_start') }}" class="btn btn-outline-primary">
+                                                        <i class="bi bi-microsoft" aria-hidden="true"></i>
+                                                        Lier Microsoft
+                                                    </a>
+                                                {% endif %}
+                                            </div>
+                                            <p class="text-muted small mt-2 mb-0">
+                                                Pour éviter la prise de contrôle par e-mail, un compte OAuth existant ne peut être lié qu'après connexion à ce profil.
+                                            </p>
+                                        </div>
+
                                         {% if user.isVerified == 0 %}
                                             <div class="alert alert-warning" role="alert">
                                                 <h3 class="h6 mb-2">


### PR DESCRIPTION
### Motivation
- Prevent account takeover where an OAuth provider account is linked to an existing site account solely by matching email during an unauthenticated login. 
- Force explicit linking from the authenticated user profile and add checks to avoid reusing or replacing provider identifiers.

### Description
- Enforce safe linking logic in Google OAuth callback by requiring the target user to be authenticated to link, refusing automatic email-based linking, checking for existing `googleId` reuse, and sending verification emails when needed (changes in `app/src/Security/GoogleAuthenticator.php`).
- Apply the same safe linking flow for Microsoft/Azure OAuth with provider-specific email extraction and reuse checks (changes in `app/src/Security/OutlookAuthenticator.php`).
- Add UI controls to the user profile to show link state and start linking flows with `connect_google_start` and `connect_outlook_start` (changes in `app/templates/profil/index.html.twig`).
- Add Doctrine-level uniqueness constraints for provider identifiers (`googleId`, `azureId`) and a migration to create unique indexes to prevent duplicate provider IDs in the database (changes in `app/src/Entity/User.php` and new migration `app/migrations/Version20260621120000.php`).

### Testing
- Ran PHP syntax checks with `php -l` on `app/src/Security/GoogleAuthenticator.php`, `app/src/Security/OutlookAuthenticator.php`, `app/src/Entity/User.php`, and `app/migrations/Version20260621120000.php`, all succeeded. 
- Attempted `php bin/console lint:twig` and container lints inside `app/`, but execution was blocked because Composer dependencies are not installed in the environment. 
- Attempted `composer install` to enable full lints, but it failed due to environment PHP version incompatibility with locked packages (lock file requires `<8.5.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3746badc5883219ac80818bc97d3e0)