### PR TITLE
Secure OAuth account linking

### DIFF
--- a/app/src/Security/GoogleAuthenticator.php
+++ b/app/src/Security/GoogleAuthenticator.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
@@ -30,8 +31,9 @@ class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationE
     private UserPasswordHasherInterface $passwordHasher;
     private EmailService $emailService;
     private LoggerInterface $logger;
+    private Security $security;
   
-    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher, EmailService $emailService, LoggerInterface $logger)
+    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher, EmailService $emailService, LoggerInterface $logger, Security $security)
     {
         $this->clientRegistry = $clientRegistry;
         $this->entityManager = $entityManager;
@@ -39,6 +41,7 @@ class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationE
         $this->passwordHasher = $passwordHasher;
         $this->emailService = $emailService;
         $this->logger = $logger;
+        $this->security = $security;
     }
 
     /**
@@ -80,10 +83,22 @@ class GoogleAuthenticator extends OAuth2Authenticator implements AuthenticationE
                 $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
 
                 if ($existingUser) {
-                    // L'utilisateur existe avec cet email, on lie le compte Google
+                    $currentUser = $this->security->getUser();
+
+                    if (!$currentUser instanceof User || $currentUser->getId() !== $existingUser->getId()) {
+                        throw new CustomUserMessageAuthenticationException(
+                            'Un compte existe déjà avec cet email. Connectez-vous d’abord avec votre mot de passe, puis liez Google depuis votre profil.'
+                        );
+                    }
+
+                    if ($existingUser->getGoogleId() !== null && $existingUser->getGoogleId() !== $googleId) {
+                        throw new CustomUserMessageAuthenticationException('Ce compte Google ne correspond pas au compte déjà lié à votre profil.');
+                    }
+
                     $existingUser->setGoogleId($googleId);
                     $this->entityManager->persist($existingUser);
                     $this->entityManager->flush();
+
                     return $this->ensureVerified($existingUser);
                 }
 

--- a/app/src/Security/OutlookAuthenticator.php
+++ b/app/src/Security/OutlookAuthenticator.php
@@ -9,10 +9,12 @@ use KnpU\OAuth2ClientBundle\Security\Authenticator\OAuth2Authenticator;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -25,13 +27,15 @@ class OutlookAuthenticator extends OAuth2Authenticator implements Authentication
     private EntityManagerInterface $entityManager;
     private RouterInterface $router;
     private UserPasswordHasherInterface $passwordHasher;
+    private Security $security;
 
-    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher)
+    public function __construct(ClientRegistry $clientRegistry, EntityManagerInterface $entityManager, RouterInterface $router, UserPasswordHasherInterface $passwordHasher, Security $security)
     {
         $this->clientRegistry = $clientRegistry;
         $this->entityManager = $entityManager;
         $this->router = $router;
         $this->passwordHasher = $passwordHasher;
+        $this->security = $security;
     }
 
     public function supports(Request $request): ?bool
@@ -79,7 +83,18 @@ class OutlookAuthenticator extends OAuth2Authenticator implements Authentication
                     ->findOneBy(['email' => $email]);
 
                 if ($user) {
-                    // Lier le compte existant avec Azure
+                    $currentUser = $this->security->getUser();
+
+                    if (!$currentUser instanceof User || $currentUser->getId() !== $user->getId()) {
+                        throw new CustomUserMessageAuthenticationException(
+                            'Un compte existe déjà avec cet email. Connectez-vous d’abord avec votre mot de passe, puis liez Microsoft depuis votre profil.'
+                        );
+                    }
+
+                    if ($user->getAzureId() !== null && $user->getAzureId() !== $azureId) {
+                        throw new CustomUserMessageAuthenticationException('Ce compte Microsoft ne correspond pas au compte déjà lié à votre profil.');
+                    }
+
                     $user->setAzureId($azureId);
                 } else {
                     // Créer un nouvel utilisateur

--- a/app/templates/profil/index.html.twig
+++ b/app/templates/profil/index.html.twig
@@ -196,6 +196,41 @@
                                             <strong>Identifiant :</strong> {{ user.id }}
                                         </p>
 
+                                        <div class="mt-3" aria-labelledby="oauth-links-title">
+                                            <h3 id="oauth-links-title" class="h6 mb-2">
+                                                <i class="bi bi-shield-lock" aria-hidden="true"></i>
+                                                Connexions OAuth liées
+                                            </h3>
+                                            <div class="d-flex flex-column flex-sm-row gap-2">
+                                                {% if user.googleId %}
+                                                    <span class="btn btn-outline-success btn-sm disabled" aria-disabled="true">
+                                                        <i class="bi bi-google" aria-hidden="true"></i>
+                                                        Google lié
+                                                    </span>
+                                                {% else %}
+                                                    <a href="{{ path('connect_google_start') }}" class="btn btn-outline-danger btn-sm">
+                                                        <i class="bi bi-google" aria-hidden="true"></i>
+                                                        Lier Google
+                                                    </a>
+                                                {% endif %}
+
+                                                {% if user.azureId %}
+                                                    <span class="btn btn-outline-success btn-sm disabled" aria-disabled="true">
+                                                        <i class="bi bi-microsoft" aria-hidden="true"></i>
+                                                        Microsoft lié
+                                                    </span>
+                                                {% else %}
+                                                    <a href="{{ path('connect_outlook_start') }}" class="btn btn-outline-primary btn-sm">
+                                                        <i class="bi bi-microsoft" aria-hidden="true"></i>
+                                                        Lier Microsoft
+                                                    </a>
+                                                {% endif %}
+                                            </div>
+                                            <p class="text-muted small mt-2 mb-0">
+                                                Pour éviter une prise de contrôle, un compte OAuth ne peut être lié à cet email que depuis cette session déjà authentifiée.
+                                            </p>
+                                        </div>
+
                                         {% if user.isVerified == 0 %}
                                             <div class="alert alert-warning" role="alert">
                                                 <h3 class="h6 mb-2">


### PR DESCRIPTION
### Motivation
- Empêcher la prise de contrôle de comptes par « liaison par email » seule lors d’une connexion OAuth (Google / Microsoft). 
- Forcer la liaison d’un fournisseur OAuth à se faire depuis une session déjà authentifiée pour l’utilisateur local correspondant.

### Description
- GoogleAuthenticator: injection du service `Security` et vérification que l’utilisateur local trouvé par email est bien l’utilisateur actuellement connecté avant de lier `googleId`, avec message utilisateur en cas de refus et détection de conflit d’identifiants. (`app/src/Security/GoogleAuthenticator.php`)
- OutlookAuthenticator: même protection ajoutée pour Azure/Microsoft, injection de `Security`, contrôle de session et gestion des conflits d’`azureId`. (`app/src/Security/OutlookAuthenticator.php`)
- Profil utilisateur: ajout d’une section « Connexions OAuth liées » affichant l’état de liaison Google/Microsoft et boutons pour démarrer la liaison depuis le profil (le flux exige maintenant une session authentifiée). (`app/templates/profil/index.html.twig`)
- Changements non invasifs sur la création automatique d’utilisateurs OAuth: la logique de création existante est conservée pour les nouveaux emails, la liaison automatique sur email existant est désormais conditionnée à la session.

### Testing
- Syntaxe PHP vérifiée avec `php -l app/src/Security/GoogleAuthenticator.php` (succès). 
- Syntaxe PHP vérifiée avec `php -l app/src/Security/OutlookAuthenticator.php` (succès). 
- `php app/bin/console lint:twig app/templates/profil/index.html.twig` n’a pas pu être exécuté dans cet environnement car les dépendances Composer sont absentes (exécuter `composer install` avant de lancer le linter).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a37560f6d048321be677a78b05c843d)