### PR TITLE
Fix footer associations label typo

### DIFF
--- a/app/templates/_partials/footer.html.twig
+++ b/app/templates/_partials/footer.html.twig
@@ -108,7 +108,7 @@
 							</a>
 							<ul class="dropdown-menu">
 								<li>
-									<a class="dropdown-item " href="{{ path('app_asso_recommander') }}">Associations recommandeés</a>
+									<a class="dropdown-item " href="{{ path('app_asso_recommander') }}">Associations recommandées</a>
 								</li>
 
 								<li>


### PR DESCRIPTION
### Motivation
- Correct a small typo in the footer link so the label displays the proper accented French: "Associations recommandées".

### Description
- Update `app/templates/_partials/footer.html.twig` to replace `Associations recommandeés` with `Associations recommandées`.

### Testing
- Ran `rg -n "Associations recommandées|Associations recommandeés" app/templates/_partials/footer.html.twig` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a396d5299e0832192e7612aaf3f8132)