### PR TITLE
Ajout d'une mention de transparence sur les images générées/par assistées par IA

### DIFF
--- a/app/templates/mention_legales/charte_chatbot_ia.html.twig
+++ b/app/templates/mention_legales/charte_chatbot_ia.html.twig
@@ -8,4 +8,9 @@
     <p>Les réponses générées automatiquement peuvent comporter des erreurs, omissions ou approximations. Elles ne constituent pas un avis professionnel, juridique, médical, fiscal ou administratif.</p>
     <p>Les échanges avec le chatbot peuvent être traités techniquement afin de fournir le service, d’en assurer la sécurité et d’en améliorer le fonctionnement, dans les conditions précisées dans la <a href="{{ path('app_politique_confidentialite') }}">Politique de confidentialité</a>.</p>
 </section>
+
+<section id="autres-contenus-ia" aria-labelledby="autres-contenus-ia-title">
+    <h2 id="autres-contenus-ia-title">Autres contenus générés ou assistés par IA</h2>
+    <p>Au-delà du chatbot, certaines images, illustrations ou éléments graphiques publiés sur le site peuvent être générés, retouchés ou enrichis à l’aide d’outils d’intelligence artificielle. Ces contenus sont utilisés à des fins d’illustration ou de communication, avec un objectif de transparence envers les utilisateurs.</p>
+</section>
 {% endblock %}

--- a/app/templates/mention_legales/mentions_legales.html.twig
+++ b/app/templates/mention_legales/mentions_legales.html.twig
@@ -30,6 +30,13 @@
     <p>Les contenus présents sur le site, notamment les textes, images, graphismes, logos, vidéos, icônes et sons, sont protégés par le droit de la propriété intellectuelle. Toute reproduction, représentation, modification, publication ou adaptation de tout ou partie des éléments du site est interdite sans autorisation écrite préalable de l’association GNUT 06, sauf usages autorisés par la loi.</p>
 </section>
 
+<section id="images-contenus-ia" aria-labelledby="images-contenus-ia-title">
+    <h2 id="images-contenus-ia-title">Images et contenus générés par intelligence artificielle</h2>
+    <p>Dans un souci de transparence, l’association GNUT 06 informe les utilisateurs que certaines images, illustrations, visuels, icônes ou éléments graphiques présents sur le site peuvent avoir été générés, retouchés ou enrichis à l’aide d’outils d’intelligence artificielle.</p>
+    <p>Ces contenus sont utilisés à des fins d’illustration, de communication ou de médiation numérique. Lorsqu’un contenu représente une personne, un événement, un témoignage ou une situation réelle, GNUT 06 veille à éviter toute présentation trompeuse.</p>
+    <p>Les photographies d’événements, de bénévoles, de partenaires ou de participants sont, sauf mention contraire, distinguées des visuels d’illustration générés ou modifiés par IA.</p>
+</section>
+
 <section id="responsabilite" aria-labelledby="responsabilite-title">
     <h2 id="responsabilite-title">Responsabilité éditoriale</h2>
     <p>L’association GNUT 06 s’efforce de fournir des informations aussi exactes et à jour que possible. Des erreurs, omissions ou indisponibilités peuvent toutefois survenir. Les informations publiées sont fournies à titre indicatif et peuvent être modifiées.</p>


### PR DESCRIPTION
### Motivation
- Informer de manière concise et transparente que certaines images, illustrations ou éléments graphiques du site peuvent être générés, retouchés ou enrichis à l’aide d’outils d’intelligence artificielle sans alourdir le contenu existant.

### Description
- Ajout d’une section `Images et contenus générés par intelligence artificielle` dans `app/templates/mention_legales/mentions_legales.html.twig` précisant que certaines images peuvent être IA‑assistées et distinguant les photographies réelles des visuels d’illustration modifiés ou générés par IA.
- Ajout d’une sous‑section `Autres contenus générés ou assistés par IA` dans `app/templates/mention_legales/charte_chatbot_ia.html.twig` rappelant que, au‑delà du chatbot, certains visuels peuvent être assistés par IA.
- Aucune autre information de conformité, footer ou données légales existantes n’a été modifiée.

### Testing
- Exécution de `git diff --check` a réussi et n’a pas retourné d’erreurs de style sur les fichiers modifiés.
- Recherche textuelle avec `rg -n "Images et contenus générés|certaines images|photographies d’événements|Autres contenus générés"` a confirmé la présence des textes ajoutés dans les deux templates concernés.
- `php bin/console lint:twig` n’a pas pu être exécuté dans cet environnement car les dépendances Composer manquent, l’erreur renvoyée indiquant « Try running \"composer install\" ».

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a399041f11c8321b9c271bb76c92398)