### PR TITLE
fix: move asso CRUD route under /admin to restrict to admins

### DIFF
--- a/app/config/packages/security.yaml
+++ b/app/config/packages/security.yaml
@@ -40,7 +40,6 @@ security:
     # Note: Only the *first* access control that matches will be used
     access_control:
         - { path: ^/admin, roles: ROLE_ADMIN }
-        - { path: ^/assos/crud, roles: ROLE_ADMIN }
         - { path: ^/oauth-test, roles: ROLE_ADMIN }
         - { path: ^/connect/outlook, roles: PUBLIC_ACCESS }
         - { path: ^/connect/google, roles: PUBLIC_ACCESS }

--- a/app/src/Controller/AssosCrudController.php
+++ b/app/src/Controller/AssosCrudController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
-#[Route('/assos/crud')]
+#[Route('/admin/assos/crud')]
 #[IsGranted('ROLE_ADMIN')]
 class AssosCrudController extends AbstractController
 {


### PR DESCRIPTION
La route /assos/crud est déplacée vers /admin/assos/crud pour sécuriser le CRUD association et le réserver aux administrateurs (couvert par la règle ^/admin).

Changements

- AssosCrudController.php : #[Route('/assos/crud')] → #[Route('/admin/assos/crud')]
- security.yaml : suppression de la règle redondante ^/assos/crud (déjà couverte par ^/admin)

Les noms de routes ne changent pas, donc tous les liens existants continuent de fonctionner.

[Taiga #63](https://tree.taiga.io/project/assognut06-symfony-gnut-06/us/63?kanban-status=10661025)
