### PR TITLE
Refactor user profile picture property typing

### DIFF
--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -49,8 +49,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToOne(mappedBy: 'user', targetEntity: Tih::class, cascade: ['persist', 'remove'])]
     private ?Tih $tih = null;
 
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
-    private $profile_picture;
+    #[ORM\Column(name: 'profile_picture', type: 'string', length: 255, nullable: true)]
+    private ?string $profilePicture = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $googleId = null;
@@ -176,12 +176,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function getProfilePicture(): ?string
     {
-        return $this->profile_picture;
+        return $this->profilePicture;
     }
     
-    public function setProfilePicture(?string $profile_picture): self
+    public function setProfilePicture(?string $profilePicture): self
     {
-        $this->profile_picture = $profile_picture;
+        $this->profilePicture = $profilePicture;
         return $this;
     }
 


### PR DESCRIPTION
## Summary
- Rename the `User` profile picture property from `$profile_picture` to `$profilePicture`
- Add explicit `?string` typing
- Keep Doctrine mapped to `profile_picture`
- No Doctrine migration is included in this change
- If a migration is later required, it can be added separately

## Why
This property was the only untyped snake_case field in `User`.
The change aligns it with nearby fields such as `googleId` and `azureId`.

## Validation
- Cleared Symfony cache in `dev` and `prod`
- Confirmed the previous Doctrine metadata error on `User::$profile_picture` disappeared
- Ran `doctrine:schema:validate`
- Validation is still blocked by an unrelated mapping issue between `EntrepriseTihMessage` and `Tih`
