### PR TITLE
Fix admin TIH document links

### DIFF
--- a/app/src/Controller/AdminTihController.php
+++ b/app/src/Controller/AdminTihController.php
@@ -5,8 +5,10 @@ namespace App\Controller;
 use App\Entity\Tih;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -57,6 +59,40 @@ class AdminTihController extends AbstractController
             'page_size' => self::PAGE_SIZE,
             'query'     => $q,
         ]);
+    }
+
+    #[Route('/admin/tih/{id}/cv', name: 'app_admin_tih_cv', requirements: ['id' => '\d+'], methods: ['GET'])]
+    public function downloadCv(EntityManagerInterface $em, int $id): Response
+    {
+        $tih = $this->findTihOrFail($em, $id);
+
+        if (!$tih->getCv()) {
+            throw $this->createNotFoundException('CV introuvable.');
+        }
+
+        return $this->createInlineFileResponse(
+            (string) $tih->getCv(),
+            (string) $this->getParameter('cv_tih_directory'),
+            'public/uploads/tihcv',
+            'CV introuvable.'
+        );
+    }
+
+    #[Route('/admin/tih/{id}/attestation', name: 'app_admin_tih_attestation', requirements: ['id' => '\d+'], methods: ['GET'])]
+    public function downloadAttestation(EntityManagerInterface $em, int $id): Response
+    {
+        $tih = $this->findTihOrFail($em, $id);
+
+        if (!$tih->getAttestationTih()) {
+            throw $this->createNotFoundException('Attestation introuvable.');
+        }
+
+        return $this->createInlineFileResponse(
+            (string) $tih->getAttestationTih(),
+            (string) $this->getParameter('attestation_tih_directory'),
+            'public/uploads/tihattest',
+            'Attestation introuvable.'
+        );
     }
 
     #[Route('/admin/tih/validate/{id}', name: 'app_admin_tih_validate', methods: ['POST'])]
@@ -135,5 +171,41 @@ class AdminTihController extends AbstractController
 
         $this->addFlash('success', 'TIH supprimé avec succès.');
         return $this->redirectToRoute('app_admin_tih');
+    }
+
+    private function findTihOrFail(EntityManagerInterface $em, int $id): Tih
+    {
+        $tih = $em->getRepository(Tih::class)->find($id);
+
+        if (!$tih) {
+            throw $this->createNotFoundException('Le TIH n\'a pas été trouvé.');
+        }
+
+        return $tih;
+    }
+
+    private function createInlineFileResponse(
+        string $storedFilename,
+        string $uploadDirectory,
+        string $legacyDirectory,
+        string $notFoundMessage
+    ): BinaryFileResponse {
+        $fileName = basename($storedFilename);
+        $filePath = rtrim($uploadDirectory, '/') . '/' . $fileName;
+
+        if (!is_file($filePath)) {
+            $legacyPath = rtrim((string) $this->getParameter('kernel.project_dir'), '/') . '/' . trim($legacyDirectory, '/') . '/' . $fileName;
+
+            if (is_file($legacyPath)) {
+                $filePath = $legacyPath;
+            } else {
+                throw $this->createNotFoundException($notFoundMessage);
+            }
+        }
+
+        $response = new BinaryFileResponse($filePath);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_INLINE, $fileName);
+
+        return $response;
     }
 }

--- a/app/templates/admin/admin_tih/index.html.twig
+++ b/app/templates/admin/admin_tih/index.html.twig
@@ -110,14 +110,14 @@
                             </p>
                             <p><strong>CV :</strong>
                               {% if tih.cv %}
-                                <a href="{{ path('espace_tih_cv') }}" target="_blank" class="btn btn-outline-primary btn-sm ms-2">Voir le CV</a>
+                                <a href="{{ path('app_admin_tih_cv', {'id': tih.id}) }}" target="_blank" class="btn btn-outline-primary btn-sm ms-2">Voir le CV</a>
                               {% else %}
                                 —
                               {% endif %}
                             </p>
                             <p><strong>Attestation TIH :</strong>
                               {% if tih.attestationTih %}
-                                <a href="{{ path('espace_tih_attestation') }}" target="_blank" class="btn btn-outline-primary btn-sm ms-2">Voir l'attestation</a>
+                                <a href="{{ path('app_admin_tih_attestation', {'id': tih.id}) }}" target="_blank" class="btn btn-outline-primary btn-sm ms-2">Voir l'attestation</a>
                               {% else %}
                                 —
                               {% endif %}

--- a/app/tests/Functional/AdminTihTest.php
+++ b/app/tests/Functional/AdminTihTest.php
@@ -3,12 +3,29 @@
 namespace App\Tests\Functional;
 
 use App\Entity\Tih;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional tests for TIH administration (list, search, validate, refuse, delete).
  */
 class AdminTihTest extends WebTestCase
 {
+    /** @var string[] */
+    private array $createdFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles as $filePath) {
+            if (is_file($filePath)) {
+                unlink($filePath);
+            }
+        }
+
+        $this->createdFiles = [];
+
+        parent::tearDown();
+    }
+
     public function testIndexListsTihProfiles(): void
     {
         $this->loginAsAdmin();
@@ -92,6 +109,18 @@ class AdminTihTest extends WebTestCase
         $this->client->request('GET', '/admin/tih/2');
 
         $this->assertResponseIsSuccessful();
+    }
+
+    public function testIndexPaginationCapsRequestedPageToLastAvailablePage(): void
+    {
+        $this->loginAsAdmin();
+        $this->createTihUser('single-page-tih@test.com');
+
+        $this->client->request('GET', '/admin/tih/999');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('.pagination .page-item.active .page-link');
+        $this->assertSelectorTextSame('.pagination .page-item.active .page-link', '1');
     }
 
     public function testValidateRejectsInvalidCsrf(): void
@@ -280,5 +309,157 @@ class AdminTihTest extends WebTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testDownloadCvReturnsInlineFileFromConfiguredDirectory(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'cv-configured@test.com']);
+        $fileName = sprintf('cv-configured-%s.pdf', uniqid('', true));
+        $this->createUploadedFile('var/tihcv', $fileName, 'cv-content');
+        $tih->setCv($fileName);
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/cv');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertStringContainsString(
+            'inline; filename=' . $fileName,
+            (string) $this->client->getResponse()->headers->get('Content-Disposition')
+        );
+    }
+
+    public function testDownloadCvFallsBackToLegacyDirectory(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'cv-legacy@test.com']);
+        $fileName = sprintf('cv-legacy-%s.pdf', uniqid('', true));
+        $this->createUploadedFile('public/uploads/tihcv', $fileName, 'legacy-cv-content');
+        $tih->setCv($fileName);
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/cv');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertStringContainsString(
+            'inline; filename=' . $fileName,
+            (string) $this->client->getResponse()->headers->get('Content-Disposition')
+        );
+    }
+
+    public function testDownloadCvReturns404WhenNoCvSet(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'cv-missing-field@test.com']);
+        $tih->setCv(null);
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/cv');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testDownloadCvReturns404WhenStoredFileIsMissing(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'cv-file-missing@test.com']);
+        $tih->setCv('missing-file.pdf');
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/cv');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testDownloadCvReturns404WhenTihMissing(): void
+    {
+        $this->loginAsAdmin();
+
+        $this->client->request('GET', '/admin/tih/999999/cv');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testDownloadAttestationReturnsInlineFileFromConfiguredDirectory(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'att-configured@test.com']);
+        $fileName = sprintf('att-configured-%s.pdf', uniqid('', true));
+        $this->createUploadedFile('var/tihattest', $fileName, 'att-content');
+        $tih->setAttestationTih($fileName);
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/attestation');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertStringContainsString(
+            'inline; filename=' . $fileName,
+            (string) $this->client->getResponse()->headers->get('Content-Disposition')
+        );
+    }
+
+    public function testDownloadAttestationFallsBackToLegacyDirectory(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'att-legacy@test.com']);
+        $fileName = sprintf('att-legacy-%s.pdf', uniqid('', true));
+        $this->createUploadedFile('public/uploads/tihattest', $fileName, 'legacy-att-content');
+        $tih->setAttestationTih($fileName);
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/attestation');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertStringContainsString(
+            'inline; filename=' . $fileName,
+            (string) $this->client->getResponse()->headers->get('Content-Disposition')
+        );
+    }
+
+    public function testDownloadAttestationReturns404WhenNoFileSet(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'att-missing-field@test.com']);
+        $tih->setAttestationTih(null);
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/attestation');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testDownloadAttestationReturns404WhenStoredFileIsMissing(): void
+    {
+        $this->loginAsAdmin();
+        $tih = $this->createSearchableTih(['email' => 'att-file-missing@test.com']);
+        $tih->setAttestationTih('missing-attestation.pdf');
+        $this->em->flush();
+
+        $this->client->request('GET', '/admin/tih/' . $tih->getId() . '/attestation');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    public function testDownloadAttestationReturns404WhenTihMissing(): void
+    {
+        $this->loginAsAdmin();
+
+        $this->client->request('GET', '/admin/tih/999999/attestation');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    private function createUploadedFile(string $relativeDirectory, string $fileName, string $content): void
+    {
+        $projectDir = (string) static::getContainer()->getParameter('kernel.project_dir');
+        $directory = rtrim($projectDir, '/') . '/' . trim($relativeDirectory, '/');
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        $filePath = $directory . '/' . $fileName;
+        file_put_contents($filePath, $content);
+        $this->createdFiles[] = $filePath;
     }
 }

--- a/app/tests/Functional/AdminTihTest.php
+++ b/app/tests/Functional/AdminTihTest.php
@@ -35,6 +35,52 @@ class AdminTihTest extends WebTestCase
         $this->assertSelectorTextNotContains('table#tih-table', 'beta-tih@test.com');
     }
 
+    public function testIndexSearchFiltersByProfessionalEmail(): void
+    {
+        $this->loginAsAdmin();
+        $this->createSearchableTih([
+            'email' => 'account-pro@example.com',
+            'professionalEmail' => 'contact-pro@example.com',
+        ]);
+        $this->createSearchableTih([
+            'email' => 'other-pro@example.com',
+            'professionalEmail' => 'other-contact@example.com',
+        ]);
+
+        $this->client->request('GET', '/admin/tih', ['q' => 'contact-pro']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('table#tih-table', 'contact-pro@example.com');
+        $this->assertSelectorTextNotContains('table#tih-table', 'other-contact@example.com');
+    }
+
+    public function testIndexSearchFiltersByFirstAndLastName(): void
+    {
+        $this->loginAsAdmin();
+        $this->createSearchableTih([
+            'email' => 'named-tih@example.com',
+            'firstName' => 'Camille',
+            'lastName' => 'Martin',
+        ]);
+        $this->createSearchableTih([
+            'email' => 'unnamed-tih@example.com',
+            'firstName' => 'Alex',
+            'lastName' => 'Durand',
+        ]);
+
+        $this->client->request('GET', '/admin/tih', ['q' => 'camille']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('table#tih-table', 'named-tih@example.com');
+        $this->assertSelectorTextNotContains('table#tih-table', 'unnamed-tih@example.com');
+
+        $this->client->request('GET', '/admin/tih', ['q' => 'martin']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('table#tih-table', 'named-tih@example.com');
+        $this->assertSelectorTextNotContains('table#tih-table', 'unnamed-tih@example.com');
+    }
+
     public function testIndexPagination(): void
     {
         $this->loginAsAdmin();

--- a/app/tests/Functional/WebTestCase.php
+++ b/app/tests/Functional/WebTestCase.php
@@ -136,6 +136,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *     rate?: string,
      *     rateType?: string,
      *     validated?: bool,
+     *     professionalEmail?: string,
      *     competences?: Competence[],
      * } $options
      */
@@ -153,6 +154,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $tih->setUser($user);
         $tih->setFirstName($options['firstName'] ?? 'Jean');
         $tih->setLastName($options['lastName'] ?? 'Dupont');
+        $tih->setProfessionalEmail($options['professionalEmail'] ?? null);
         $tih->setCity($options['city'] ?? 'Nice');
         $tih->setRegion($options['region'] ?? 'PACA');
         $tih->setDepartement($options['departement'] ?? null);


### PR DESCRIPTION
### Motivation
- L’interface d’administration affichait des boutons pour ouvrir le CV et l’attestation TIH en utilisant les routes de l’espace TIH de l’utilisateur connecté, ce qui pouvait afficher des fichiers incorrects pour le TIH sélectionné dans la liste d’administration.

### Description
- Ajout de deux routes admin pour télécharger le CV et l’attestation d’un TIH ciblé par son ID (`app_admin_tih_cv`, `app_admin_tih_attestation`) dans `app/src/Controller/AdminTihController.php`.
- Ajout d’un helper `findTihOrFail()` et d’un helper `createInlineFileResponse()` pour centraliser la récupération de l’entité TIH et la résolution des fichiers (chemin courant + legacy) dans `AdminTihController`.
- Mise à jour du modal admin TIH pour pointer les liens vers `app_admin_tih_cv` et `app_admin_tih_attestation` en passant `tih.id` dans `app/templates/admin/admin_tih/index.html.twig`.
- Changements commités avec le message `Fix admin TIH document links`.

### Testing
- `php -l src/Controller/AdminTihController.php` a été exécuté et a retourné `No syntax errors detected`.
- `php bin/console lint:twig templates/admin/admin_tih/index.html.twig` a été tenté mais bloqué par l’environnement car les dépendances Composer manquent (message: `Dependencies are missing. Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a46210af9088321bddc6171fbaa9849)