### PR TITLE
Add functional tests for TIH admin search and support professionalEmail in test factory

### DIFF
--- a/app/tests/Functional/AdminTihTest.php
+++ b/app/tests/Functional/AdminTihTest.php
@@ -35,6 +35,52 @@ class AdminTihTest extends WebTestCase
         $this->assertSelectorTextNotContains('table#tih-table', 'beta-tih@test.com');
     }
 
+    public function testIndexSearchFiltersByProfessionalEmail(): void
+    {
+        $this->loginAsAdmin();
+        $this->createSearchableTih([
+            'email' => 'account-pro@example.com',
+            'professionalEmail' => 'contact-pro@example.com',
+        ]);
+        $this->createSearchableTih([
+            'email' => 'other-pro@example.com',
+            'professionalEmail' => 'other-contact@example.com',
+        ]);
+
+        $this->client->request('GET', '/admin/tih', ['q' => 'contact-pro']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('table#tih-table', 'contact-pro@example.com');
+        $this->assertSelectorTextNotContains('table#tih-table', 'other-contact@example.com');
+    }
+
+    public function testIndexSearchFiltersByFirstAndLastName(): void
+    {
+        $this->loginAsAdmin();
+        $this->createSearchableTih([
+            'email' => 'named-tih@example.com',
+            'firstName' => 'Camille',
+            'lastName' => 'Martin',
+        ]);
+        $this->createSearchableTih([
+            'email' => 'unnamed-tih@example.com',
+            'firstName' => 'Alex',
+            'lastName' => 'Durand',
+        ]);
+
+        $this->client->request('GET', '/admin/tih', ['q' => 'camille']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('table#tih-table', 'named-tih@example.com');
+        $this->assertSelectorTextNotContains('table#tih-table', 'unnamed-tih@example.com');
+
+        $this->client->request('GET', '/admin/tih', ['q' => 'martin']);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('table#tih-table', 'named-tih@example.com');
+        $this->assertSelectorTextNotContains('table#tih-table', 'unnamed-tih@example.com');
+    }
+
     public function testIndexPagination(): void
     {
         $this->loginAsAdmin();

--- a/app/tests/Functional/WebTestCase.php
+++ b/app/tests/Functional/WebTestCase.php
@@ -136,6 +136,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *     rate?: string,
      *     rateType?: string,
      *     validated?: bool,
+     *     professionalEmail?: string,
      *     competences?: Competence[],
      * } $options
      */
@@ -153,6 +154,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $tih->setUser($user);
         $tih->setFirstName($options['firstName'] ?? 'Jean');
         $tih->setLastName($options['lastName'] ?? 'Dupont');
+        $tih->setProfessionalEmail($options['professionalEmail'] ?? null);
         $tih->setCity($options['city'] ?? 'Nice');
         $tih->setRegion($options['region'] ?? 'PACA');
         $tih->setDepartement($options['departement'] ?? null);


### PR DESCRIPTION
### Motivation
- Improve functional coverage for the TIH admin area by exercising search predicates beyond account email (professional contact email, first name and last name).

### Description
- Add two functional tests in `app/tests/Functional/AdminTihTest.php` to assert search by professional email and by first/last name.
- Extend the test fixture helper `createSearchableTih` in `app/tests/Functional/WebTestCase.php` to accept a `professionalEmail` option and set it on the created `Tih` entity.
- Changes are limited to test code to increase coverage of admin search behavior.

### Testing
- `php -l tests/Functional/AdminTihTest.php` succeeded with no syntax errors.
- `php -l tests/Functional/WebTestCase.php` succeeded with no syntax errors and `git diff --check` reported no issues.
- Attempts to run full PHPUnit with coverage failed because project dependencies are not installed in this environment (`composer install` blocked by PHP platform mismatch and subsequent download errors), so `vendor`/PHPUnit were not available and coverage generation (`var/coverage/clover.xml`) could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a463040bf8c8321ab3394d2c1f4c8e2)