### PR TITLE
Move Encore JavaScript bundles into the document head

### DIFF
--- a/app/templates/admin/base.html.twig
+++ b/app/templates/admin/base.html.twig
@@ -12,40 +12,10 @@
 		{% include 'admin/_partials/header.html.twig' %}
 		{% block stylesheets %}{{ encore_entry_link_tags('app') }}{% endblock %}
 		<link rel="stylesheet" href="{{ asset('css/admin_table.css') }}">
-	</head>
-	<body>
-		<!-- Include navbar -->
-		{% include 'admin/_partials/navbar.html.twig' %}
-
-
-		{% include 'admin/_partials/nav_tabs.html.twig' %}
-		<!-- Spinner de Chargement -->
-		
-
-		<!-- Display flash messages -->
-		{% for type, messages in app.flashes %}
-			{% for message in messages %}
-				<div class="alert alert-{{ type }} text-center" role="alert">{{ message }}</div>
-			{% endfor %}
-		{% endfor %}
-
-		<!-- Body content -->
-	
-		{% include('_partials/loader.html.twig') %}
-		<main>
-           {% block body %}{% endblock %}
-        </main>
-
-		<!-- Include footer -->
-		{% include 'admin/_partials/footer.html.twig' %}
-
-		<!-- Include scripts -->
-		{% include 'admin/_partials/scripts.html.twig' %}
-
-		<!-- Include javascripts -->
+		<!-- Include javascripts in <head> so Turbo is initialized only once per page load -->
 		{% block javascripts %}
 			{{ encore_entry_script_tags('app') }}
-			   <script>
+			<script>
             document.addEventListener("DOMContentLoaded", function() {
                 var loader = document.getElementById('loader');
 
@@ -86,5 +56,35 @@
             });
         </script>
         {% endblock %}
+	</head>
+	<body>
+		<!-- Include navbar -->
+		{% include 'admin/_partials/navbar.html.twig' %}
+
+
+		{% include 'admin/_partials/nav_tabs.html.twig' %}
+		<!-- Spinner de Chargement -->
+		
+
+		<!-- Display flash messages -->
+		{% for type, messages in app.flashes %}
+			{% for message in messages %}
+				<div class="alert alert-{{ type }} text-center" role="alert">{{ message }}</div>
+			{% endfor %}
+		{% endfor %}
+
+		<!-- Body content -->
+	
+		{% include('_partials/loader.html.twig') %}
+		<main>
+           {% block body %}{% endblock %}
+        </main>
+
+		<!-- Include footer -->
+		{% include 'admin/_partials/footer.html.twig' %}
+
+		<!-- Include scripts -->
+		{% include 'admin/_partials/scripts.html.twig' %}
+
 	</body>
 </html>

--- a/app/templates/admin/iframe.html.twig
+++ b/app/templates/admin/iframe.html.twig
@@ -9,6 +9,10 @@
 		<!-- Include header -->
 		{% include 'admin/_partials/header.html.twig' %}
 		{{ encore_entry_link_tags('app') }}
+		<!-- Include javascripts in <head> so Turbo is initialized only once per page load -->
+		{% block javascripts %}
+			{{ encore_entry_script_tags('app') }}
+		{% endblock %}
 	</head>
 	<body>
 		<!-- Spinner de Chargement -->
@@ -23,9 +27,5 @@
 		<!-- Include scripts -->
 		{% include 'admin/_partials/scripts.html.twig' %}
 
-		<!-- Include javascripts -->
-		{% block javascripts %}
-			{{ encore_entry_script_tags('app') }}
-		{% endblock %}
 	</body>
 </html>

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -13,6 +13,10 @@
 		{% block stylesheets %}
 			{{ encore_entry_link_tags('app') }}
 		{% endblock %}
+		<!-- Include javascripts in <head> so Turbo is initialized only once per page load -->
+		{% block javascripts %}
+			{{ encore_entry_script_tags('app') }}
+		{% endblock %}
 		{% include '_partials/analytics.html.twig' %}
 	</head>
 	<body>
@@ -42,10 +46,5 @@
 
 		{# Include agent AI #}
 		{% include '_partials/chatbot.html.twig' %}
-
-		<!-- Include javascripts -->
-		{% block javascripts %}
-			{{ encore_entry_script_tags('app') }}
-		{% endblock %}
 	</body>
 </html>


### PR DESCRIPTION
### Motivation
- Prevent Turbo from being re-initialized on every page change by avoiding loading the main app script from inside the `<body>`.
- Ensure the application JavaScript bundle is evaluated once when the document is first parsed so Turbo works correctly across body swaps.
- Apply the same behavior to admin layouts and iframe layout to keep script loading consistent across front and admin UIs.

### Description
- Move the `{{ encore_entry_script_tags('app') }}` block from the end of `<body>` into the `<head>` in `app/templates/base.html.twig` so the main Encore bundle is loaded in the head.
- Move the admin bundle into the head in `app/templates/admin/base.html.twig` and keep the admin loader script inside the `javascripts` block rendered in the head and still guarded by `DOMContentLoaded`.
- Move the iframe layout bundle into the head in `app/templates/admin/iframe.html.twig` and remove the duplicate body-level `javascripts` block.
- Change layout ordering so page-level includes and footer remain in the body while Encore script tags are provided from the head to avoid Turbo warnings.

### Testing
- Ran `cd app && composer validate --no-check-publish` which completed successfully (composer warnings only). 
- Attempted `cd app && php bin/console lint:twig templates/base.html.twig templates/admin/base.html.twig templates/admin/iframe.html.twig` which failed because project dependencies are not installed and reported `Dependencies are missing. Try running "composer install"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a467d60e7b48321ac4a2ae5b5b6b891)