### PR TITLE
Fix dev deploy after divergent branch history

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -159,8 +159,11 @@ jobs:
             else
               git fetch origin "$DEPLOY_BRANCH"
             fi
-            git checkout "$DEPLOY_BRANCH"
-            git pull --ff-only origin "$DEPLOY_BRANCH"
+            # The deploy working tree must exactly match the remote branch.
+            # Using checkout/reset handles forced updates and discarded local deploy-only commits
+            # without failing on divergent history like `git pull --ff-only` does.
+            git checkout -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"
+            git reset --hard "origin/$DEPLOY_BRANCH"
             echo "🌿 Deploying branch: $DEPLOY_BRANCH"
 
             # Aller dans le dossier app


### PR DESCRIPTION
### Motivation
- The dev deployment job failed when the remote branch was force-updated or the server working tree contained divergent local commits, producing a non-fast-forward error from `git pull --ff-only`.
- The deployment must ensure the server checkout matches the remote branch exactly to guarantee reproducible deployments.

### Description
- Updated `.github/workflows/deploy-dev.yml` to replace the fragile `git checkout "$DEPLOY_BRANCH"` + `git pull --ff-only origin "$DEPLOY_BRANCH"` sequence with a forced sync using `git checkout -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"` followed by `git reset --hard "origin/$DEPLOY_BRANCH"`.
- Added explanatory comments in the workflow to document why a checkout/reset is used (handles forced updates and discarded local deploy-only commits).
- Change is limited to the development deployment workflow file at `.github/workflows/deploy-dev.yml`.

### Testing
- Validated the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-dev.yml")'` which returned OK.
- Ran `git diff --check` to ensure no whitespace or diff errors and it passed.
- Attempted to validate with `python3` + `PyYAML`, but `PyYAML` was not available in the environment so that specific check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a46806e71c88321b60129ef1aaafd45)