### PR TITLE
Provide profile detailUrl in map DTO and simplify frontend map data

### DIFF
--- a/app/assets/controllers/tih-search_controller.js
+++ b/app/assets/controllers/tih-search_controller.js
@@ -502,10 +502,6 @@ export default class extends Controller {
         }
     }
 
-    profileDetailUrl(profile) {
-        return profile.detailUrl || `/tih/tih/${profile.id}`;
-    }
-
     createCarouselPopup(profiles, city) {
         if (profiles.length === 1) {
             const profile = profiles[0];
@@ -515,7 +511,7 @@ export default class extends Controller {
                     <p class="mb-1"><i class="bi bi-geo-alt"></i> ${profile.postalCode} ${profile.city}</p>
                     ${profile.rate ? `<p class="mb-1"><i class="bi bi-currency-euro"></i> ${profile.rate}€ / ${profile.rateType}</p>` : ''}
                     ${profile.availability ? `<p class="mb-2"><small>${profile.availability}</small></p>` : ''}
-                    <a href="${this.profileDetailUrl(profile)}" class="btn btn-sm btn-primary w-100">Voir le profil</a>
+                    <a href="${profile.detailUrl}" class="btn btn-sm btn-primary w-100">Voir le profil</a>
                 </div>
             `;
         }
@@ -530,7 +526,7 @@ export default class extends Controller {
                     ${profile.rate ? `<p class="mb-1"><i class="bi bi-currency-euro"></i> ${profile.rate}€ / ${profile.rateType}</p>` : ''}
                     ${profile.availability ? `<p class="mb-2"><small>${profile.availability}</small></p>` : ''}
                     <div class="d-flex gap-2 align-items-center">
-                        <a href="${this.profileDetailUrl(profile)}" class="btn btn-sm btn-primary flex-grow-1">Voir le profil</a>
+                        <a href="${profile.detailUrl}" class="btn btn-sm btn-primary flex-grow-1">Voir le profil</a>
                         <span class="badge bg-secondary">${index + 1}/${profiles.length}</span>
                     </div>
                 </div>

--- a/app/src/Application/DTO/Tih/TihMapProfileDTO.php
+++ b/app/src/Application/DTO/Tih/TihMapProfileDTO.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Application\DTO\Tih;
+
+use App\Entity\Tih;
+
+final readonly class TihMapProfileDTO implements \JsonSerializable
+{
+    public function __construct(
+        public ?int $id,
+        public ?string $firstName,
+        public ?string $lastName,
+        public ?string $city,
+        public ?string $postalCode,
+        public ?string $photo,
+        public ?string $rate,
+        public ?string $rateType,
+        public ?string $availability,
+        public ?string $availabilityDate,
+        public string $detailUrl,
+    ) {
+    }
+
+    public static function fromEntity(Tih $tih, string $detailUrl): self
+    {
+        return new self(
+            id: $tih->getId(),
+            firstName: $tih->getFirstName(),
+            lastName: $tih->getLastName(),
+            city: $tih->getCity(),
+            postalCode: $tih->getPostalCode(),
+            photo: $tih->getPhoto(),
+            rate: $tih->getRate(),
+            rateType: $tih->getRateType(),
+            availability: $tih->getAvailability(),
+            availabilityDate: $tih->getAvailabilityDate()?->format('Y-m-d'),
+            detailUrl: $detailUrl,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id' => $this->id,
+            'firstName' => $this->firstName,
+            'lastName' => $this->lastName,
+            'city' => $this->city,
+            'postalCode' => $this->postalCode,
+            'photo' => $this->photo,
+            'rate' => $this->rate,
+            'rateType' => $this->rateType,
+            'availability' => $this->availability,
+            'availabilityDate' => $this->availabilityDate,
+            'detailUrl' => $this->detailUrl,
+        ];
+    }
+}

--- a/app/src/Controller/IntranetTihSearchController.php
+++ b/app/src/Controller/IntranetTihSearchController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Application\Command\CommandBus;
 use App\Application\Command\Tih\SendTihContactCommand;
 use App\Application\DTO\Tih\TihContactDTO;
+use App\Application\DTO\Tih\TihMapProfileDTO;
 use App\Application\Query\QueryBus;
 use App\Application\Query\Tih\GetAvailableFiltersQuery;
 use App\Application\Query\Tih\SearchTihQuery;
@@ -97,7 +98,7 @@ class IntranetTihSearchController extends AbstractController
 
         return $this->render('tih_search/intranet/index.html.twig', [
             'tihs' => $paginator,
-            'allTihs' => iterator_to_array($allFilteredResults),
+            'allTihs' => $this->buildMapProfiles($allFilteredResults, 'intranet_tih_details'),
             'currentFilters' => $filters,
             'availableFilters' => $availableFilters,
             'currentPage' => $page,
@@ -107,6 +108,25 @@ class IntranetTihSearchController extends AbstractController
             'cityCoordinates' => $this->geocodeService->getCitiesCoordinates($cities),
             'googleMapsApiKey' => $this->googleMapsApiKey,
         ]);
+    }
+
+    /**
+     * @param iterable<Tih> $tihs
+     *
+     * @return TihMapProfileDTO[]
+     */
+    private function buildMapProfiles(iterable $tihs, string $detailRoute): array
+    {
+        $profiles = [];
+
+        foreach ($tihs as $tih) {
+            $profiles[] = TihMapProfileDTO::fromEntity(
+                $tih,
+                $this->generateUrl($detailRoute, ['id' => $tih->getId()])
+            );
+        }
+
+        return $profiles;
     }
 
     #[Route('/tih/{id}', name: 'intranet_tih_details', requirements: ['id' => '\d+'], methods: ['GET'])]

--- a/app/src/Controller/TihSearchController.php
+++ b/app/src/Controller/TihSearchController.php
@@ -8,6 +8,7 @@ use App\Application\Query\QueryBus;
 use App\Application\Query\Tih\GetAvailableFiltersQuery;
 use App\Application\Query\Tih\SearchTihQuery;
 use App\Application\DTO\Tih\TihContactDTO;
+use App\Application\DTO\Tih\TihMapProfileDTO;
 use App\Application\ViewModel\Tih\TihContactViewModel;
 use App\Application\ViewModel\Tih\TihDetailsViewModel;
 use App\Entity\Tih;
@@ -113,7 +114,7 @@ class TihSearchController extends AbstractController
 
         return $this->render('tih_search/index.html.twig', [
             'tihs' => $paginator,
-            'allTihs' => iterator_to_array($allFilteredResults), // All results for map
+            'allTihs' => $this->buildMapProfiles($allFilteredResults, 'app_tih_details'), // All results for map
             'currentFilters' => $filters,
             'availableFilters' => $availableFilters,
             'currentPage' => $page,
@@ -123,6 +124,25 @@ class TihSearchController extends AbstractController
             'cityCoordinates' => $cityCoordinates,
             'googleMapsApiKey' => $this->googleMapsApiKey,
         ]);
+    }
+
+    /**
+     * @param iterable<Tih> $tihs
+     *
+     * @return TihMapProfileDTO[]
+     */
+    private function buildMapProfiles(iterable $tihs, string $detailRoute): array
+    {
+        $profiles = [];
+
+        foreach ($tihs as $tih) {
+            $profiles[] = TihMapProfileDTO::fromEntity(
+                $tih,
+                $this->generateUrl($detailRoute, ['id' => $tih->getId()])
+            );
+        }
+
+        return $profiles;
     }
 
     #[Route('/tih/{id}', name: 'app_tih_details', methods: ['GET'])]

--- a/app/templates/tih_search/index.html.twig
+++ b/app/templates/tih_search/index.html.twig
@@ -11,18 +11,7 @@
 <main class="bg-main min-vh-100 py-5" role="main" 
       data-controller="tih-search"
       data-tih-search-url-value="{{ path('app_tih_search') }}"
-      data-tih-search-profiles-value="{{ allTihs|map(profile => {
-        'id': profile.id,
-        'firstName': profile.firstName,
-        'lastName': profile.lastName,
-        'city': profile.city,
-        'postalCode': profile.postalCode,
-        'photo': profile.photo,
-        'rate': profile.rate,
-        'rateType': profile.rateType,
-        'availability': profile.availability,
-        'availabilityDate': profile.availabilityDate ? profile.availabilityDate|date('Y-m-d') : null
-      })|json_encode|e('html_attr') }}"
+      data-tih-search-profiles-value="{{ allTihs|json_encode|e('html_attr') }}"
       data-tih-search-api-key-value="{{ googleMapsApiKey }}"
       data-tih-search-city-coordinates-value="{{ cityCoordinates|json_encode|e('html_attr') }}"
       data-action="popstate@window->tih-search&#35;handleBrowserNavigation">

--- a/app/templates/tih_search/intranet/index.html.twig
+++ b/app/templates/tih_search/intranet/index.html.twig
@@ -11,19 +11,7 @@
 <main class="bg-main min-vh-100 py-5" role="main" 
       data-controller="tih-search"
       data-tih-search-url-value="{{ path('intranet_tih_search') }}"
-      data-tih-search-profiles-value="{{ allTihs|map(profile => {
-        'id': profile.id,
-        'firstName': profile.firstName,
-        'lastName': profile.lastName,
-        'city': profile.city,
-        'postalCode': profile.postalCode,
-        'photo': profile.photo,
-        'rate': profile.rate,
-        'rateType': profile.rateType,
-        'availability': profile.availability,
-        'availabilityDate': profile.availabilityDate ? profile.availabilityDate|date('Y-m-d') : null,
-        'detailUrl': path('intranet_tih_details', {'id': profile.id})
-      })|json_encode|e('html_attr') }}"
+      data-tih-search-profiles-value="{{ allTihs|json_encode|e('html_attr') }}"
       data-tih-search-api-key-value="{{ googleMapsApiKey }}"
       data-tih-search-city-coordinates-value="{{ cityCoordinates|json_encode|e('html_attr') }}"
       data-action="popstate@window->tih-search&#35;handleBrowserNavigation">


### PR DESCRIPTION
### Motivation
- Ensure map popups have a reliable `detailUrl` generated server-side instead of composing URLs in the frontend. 
- Reduce duplication and complexity in Twig by serializing map-ready profile objects on the backend. 

### Description
- Add `TihMapProfileDTO` to represent and JSON-serialize the profile data for the map, including `detailUrl` and `availabilityDate`. 
- Update `TihSearchController` and `IntranetTihSearchController` to use a new `buildMapProfiles()` helper that produces `TihMapProfileDTO` instances and generates the detail route with `generateUrl()`. 
- Simplify templates `tih_search/index.html.twig` and `tih_search/intranet/index.html.twig` to pass `allTihs|json_encode` directly to the Stimulus controller instead of mapping fields in Twig. 
- Update the Stimulus controller to remove the client-side `profileDetailUrl` helper and use the provided `profile.detailUrl` when rendering popup links. 

### Testing
- Ran the PHP test suite via `composer test` and all tests passed. 
- Built frontend assets with `yarn encore dev` to validate JS/TS changes and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a47e5bb6cec832194fc2a3b40e4a7c1)