### PR TITLE
fix: update adhesion iframe URL

### DIFF
--- a/app/templates/adhesion/index.html.twig
+++ b/app/templates/adhesion/index.html.twig
@@ -256,7 +256,7 @@
                     <iframe id="haWidget" 
                             title="Formulaire d'adhésion HelloAsso pour rejoindre l'association GNUT 06 et soutenir l'inclusion des personnes handicapées par la technologie"
                             allowtransparency="true" 
-                            src="https://www.helloasso.com/associations/gnut-06/adhesions/adhesion-a-l-association-gnut-06/widget" 
+                            src="https://www.helloasso.com/associations/gnut-06/adhesions/adhesion-a-l-association-2026/widget" 
                             style="width: 100%; border: 2px solid rgba(255, 255, 255, 0.3); border-radius: 0.375rem;" 
                             loading="lazy" 
                             aria-label="Formulaire d'adhésion sécurisé HelloAsso" 


### PR DESCRIPTION
### Motivation
- Mettre à jour l'URL du widget HelloAsso intégré sur la page d'adhésion pour pointer vers le formulaire 2026 afin d'utiliser le bon formulaire d'adhésion.

### Description
- Remplacement de la valeur `src` de l'iframe dans `app/templates/adhesion/index.html.twig` de `"https://www.helloasso.com/associations/gnut-06/adhesions/adhesion-a-l-association-gnut-06/widget"` vers `"https://www.helloasso.com/associations/gnut-06/adhesions/adhesion-a-l-association-2026/widget"`.

### Testing
- Vérification automatisée que la nouvelle URL est présente avec la commande `rg -n "src=\"https://www.helloasso.com/associations/gnut-06/adhesions/adhesion-a-l-association-2026/widget\"" app/templates/adhesion/index.html.twig`, qui a retourné une correspondance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a537b8bb4848321a2497aa30d27bf88)