### PR TITLE
Add cache-backed rate limiting to ChatbotController

### DIFF
--- a/app/config/services.yaml
+++ b/app/config/services.yaml
@@ -38,6 +38,8 @@ parameters:
     helloasso.webhook.rate_limit_max_requests: 60
     helloasso.webhook.rate_limit_window_seconds: 60
     helloasso.webhook.max_payload_bytes: 1048576
+    chatbot.rate_limit_max_requests: 20
+    chatbot.rate_limit_window_seconds: 60
 
 
 services:
@@ -163,6 +165,9 @@ services:
         arguments:
             $openAiApiKey: '%openai.api_key%'
             $openAiModel: '%openai.model%'
+            $cache: '@cache.app'
+            $chatbotRateLimitMaxRequests: '%chatbot.rate_limit_max_requests%'
+            $chatbotRateLimitWindowSeconds: '%chatbot.rate_limit_window_seconds%'
 
     App\Service\EmailService: ~
 

--- a/app/src/Controller/ChatbotController.php
+++ b/app/src/Controller/ChatbotController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,6 +16,9 @@ final class ChatbotController extends AbstractController
         private readonly HttpClientInterface $httpClient,
         private readonly string $openAiApiKey,
         private readonly string $openAiModel,
+        private readonly CacheItemPoolInterface $cache,
+        private readonly int $chatbotRateLimitMaxRequests,
+        private readonly int $chatbotRateLimitWindowSeconds,
     ) {}
 
     #[Route('/api/chatbot/ask', name: 'chatbot_ask', methods: ['POST'])]
@@ -26,6 +30,12 @@ final class ChatbotController extends AbstractController
             return $this->json([
                 'error' => 'Jeton de sécurité invalide.',
             ], 403);
+        }
+
+        if (!$this->consumeRateLimit($request)) {
+            return $this->json([
+                'error' => 'Trop de demandes. Veuillez réessayer dans quelques instants.',
+            ], 429);
         }
 
         $payload = json_decode($request->getContent(), true);
@@ -115,6 +125,29 @@ TXT;
                 'error' => 'Le chatbot est momentanément indisponible.',
             ], 500);
         }
+    }
+
+    private function consumeRateLimit(Request $request): bool
+    {
+        $user = $this->getUser();
+        $requesterIdentifier = $user !== null
+            ? 'user_' . $user->getUserIdentifier()
+            : 'ip_' . ($request->getClientIp() ?? 'anonymous');
+        $window = max(1, $this->chatbotRateLimitWindowSeconds);
+        $bucket = (int) floor(time() / $window);
+        $cacheKey = sprintf('chatbot_ask_rate_%s_%d', sha1($requesterIdentifier), $bucket);
+        $item = $this->cache->getItem($cacheKey);
+        $count = $item->isHit() ? (int) $item->get() : 0;
+
+        if ($count >= $this->chatbotRateLimitMaxRequests) {
+            return false;
+        }
+
+        $item->set($count + 1);
+        $item->expiresAfter($window * 2);
+        $this->cache->save($item);
+
+        return true;
     }
 
     private function cleanHistory(mixed $history): array


### PR DESCRIPTION
### Motivation
- Prevent abusive or excessive requests to the chatbot endpoint by enforcing a per-requester rate limit using the existing cache backend.

### Description
- Add configurable parameters `chatbot.rate_limit_max_requests` and `chatbot.rate_limit_window_seconds` to `app/config/services.yaml` and bind them into services.
- Inject `CacheItemPoolInterface` and the rate limit parameters into `App\Controller\ChatbotController` via service configuration and constructor arguments.
- Implement a `consumeRateLimit(Request $request): bool` method that keys a sliding window bucket by user id or client IP, increments a cached counter, and returns `false` when the limit is exceeded, causing the controller to return HTTP `429` with an error message.

### Testing
- Ran the project's automated test suite using `vendor/bin/phpunit` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54235cc950832191afd547afea540c)