### PR TITLE
fix: show reset password check-email help text in white

### DIFF
--- a/app/templates/reset_password/check_email.html.twig
+++ b/app/templates/reset_password/check_email.html.twig
@@ -10,6 +10,6 @@
             Ce lien expirera dans {{ resetToken.expirationMessageKey|trans(resetToken.expirationMessageData, 'ResetPasswordBundle') }}.
         </p>
     </div>
-    <p>Si vous ne recevez pas d'email, veuillez vérifier votre dossier spam ou <a href="{{ path('app_forgot_password_request') }}" class="alert-link">essayez à nouveau</a>.</p>
+    <p class="text-white">Si vous ne recevez pas d'email, veuillez vérifier votre dossier spam ou <a href="{{ path('app_forgot_password_request') }}" class="alert-link text-white">essayez à nouveau</a>.</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Ensure helper text and the retry link on the reset password check-email page are legible on the alert background by applying Bootstrap `text-white`.

### Description
- Add `class="text-white"` to the helper `<p>` and to the retry `<a>` in `app/templates/reset_password/check_email.html.twig`.

### Testing
- Ran `git diff --check` which succeeded, and attempted `cd app && php bin/console lint:twig templates/reset_password/check_email.html.twig` which was blocked due to missing PHP dependencies and reports `Dependencies are missing. Try running "composer install"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a577eb124d88321930a23cffcca425d)