### PR TITLE
Add Handi-3D promotional section to metavers page

### DIFF
--- a/app/templates/metavers/index.html.twig
+++ b/app/templates/metavers/index.html.twig
@@ -216,6 +216,56 @@ dd {
             </div>
         </section>
 
+
+
+        <!-- Présentation Handi-3D -->
+        <section class="bg-main py-5" role="region" aria-labelledby="section-handi-3d-title">
+            <div class="container">
+                <div class="card text-white bg-black border-0 shadow-lg" tabindex="0">
+                    <div class="row g-0 align-items-center">
+                        <div class="col-lg-5">
+                            <figure class="m-0 p-4 text-center">
+                                <img src="{{ asset('images/webp/handi-3D.png') }}"
+                                     class="img-fluid rounded"
+                                     alt="Illustration du projet Handi-3D, espace immersif inclusif de GNUT 06"
+                                     role="img">
+                            </figure>
+                        </div>
+                        <div class="col-lg-7">
+                            <div class="card-body p-4 p-lg-5 text-start">
+                                <p class="text-uppercase fw-bold text-primary mb-2">Projet inclusif GNUT 06</p>
+                                <h2 id="section-handi-3d-title" class="card-title mb-3">
+                                    Handi-3D : future pépinière immersive pour les TIH
+                                </h2>
+                                <p class="card-text mb-3">
+                                    Handi-3D est la future plateforme immersive de GNUT 06 dédiée aux Travailleurs Indépendants Handicapés (TIH), aux personnes en situation de handicap, à leurs aidants et aux partenaires engagés. Elle a vocation à devenir une véritable pépinière numérique où les TIH pourront valoriser leurs compétences, développer leur activité et travailler dans un environnement 3D accessible.
+                                </p>
+                                <p class="card-text mb-4">
+                                    Pensée comme une passerelle entre inclusion professionnelle, rencontres qualifiées et innovation sociale, Handi-3D permettra aussi aux TIH d'échanger avec des entreprises, de participer à des ateliers, de créer du lien sans contrainte de déplacement et d'explorer de nouvelles opportunités économiques dans un cadre bienveillant.
+                                </p>
+                                <div class="d-flex flex-column flex-sm-row gap-3">
+                                    <a href="{{ path('handi_3d_index') }}"
+                                       class="btn-neon text-white"
+                                       aria-label="Découvrir la présentation complète du projet Handi-3D">
+                                        <i class="bi bi-info-circle" aria-hidden="true"></i>
+                                        Découvrir Handi-3D
+                                    </a>
+                                    <a href="https://framevr.io/handi-metavers"
+                                       class="btn-outline-gradient text-white external-link"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       aria-label="Lancer la salle immersive Handi-3D dans un nouvel onglet">
+                                        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                                        Lancer la salle immersive
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- ✅ CORRECTION - Section étapes avec navigation clavier -->
         <section id="section-etapes" class="bg-main py-5" role="region" aria-labelledby="section-etapes-title">
             <div class="container text-center">


### PR DESCRIPTION
### Motivation
- Introduce and promote the Handi-3D project as an inclusive, immersive platform for Travailleurs Indépendants Handicapés (TIH). 
- Improve the metaverse page's discoverability and accessibility by adding a dedicated, keyboard-focusable presentation with clear CTAs. 

### Description
- Added a new responsive card section to `app/templates/metavers/index.html.twig` containing project copy, a feature image (`images/webp/handi-3D.png`) and a titled region (`Handi-3D : future pépinière immersive pour les TIH`).
- Added two calls-to-action: a local link using the route `handi_3d_index` and an external FrameVR link to `https://framevr.io/handi-metavers` with `target="_blank"` and `rel="noopener noreferrer"` and accessible `aria-label`s.
- Improved accessibility semantics by using `role="region"`, `aria-labelledby`, `tabindex="0"`, and descriptive `alt` text and button labels.
- Kept responsive layout using Bootstrap utility classes and preserved surrounding content flow.

### Testing
- Ran `git diff --check` which returned no whitespace or diff issues.
- Attempted `cd app && php bin/console lint:twig templates/metavers/index.html.twig` but the check failed due to missing Composer dependencies and requires running `composer install` to proceed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5a39c233988321a1ec81df53c10b37)