### PR TITLE
Implement sticky footer with `.site-layout` and `.site-content` wrapper

### DIFF
--- a/app/public/css/style.css
+++ b/app/public/css/style.css
@@ -638,3 +638,22 @@ h3{
 }
 
 
+
+/* Sticky footer: keeps the footer at the bottom on short pages without overlaying content. */
+html {
+  min-height: 100%;
+}
+
+body.site-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.site-content {
+  flex: 1 0 auto;
+}
+
+body.site-layout > footer {
+  flex-shrink: 0;
+}

--- a/app/templates/base.html.twig
+++ b/app/templates/base.html.twig
@@ -19,23 +19,25 @@
 		{% endblock %}
 		{% include '_partials/analytics.html.twig' %}
 	</head>
-	<body>
+	<body class="site-layout">
 		<script defer data-cfasync='false' src='https://s.clickiocdn.com/t/243913_wv.js'></script>
 		<!-- Include navbar -->
 		{% include '_partials/navbar.html.twig' %}
 
-		<!-- Include main content -->
-		{% include '_partials/main.html.twig' %}
+		<div class="site-content">
+			<!-- Include main content -->
+			{% include '_partials/main.html.twig' %}
 
-		<!-- Display flash messages -->
+			<!-- Display flash messages -->
 		{% for type, messages in app.flashes %}
 			{% for message in messages %}
 				<div class="alert alert-{{ type }}" role="alert">{{ message }}</div>
 			{% endfor %}
 		{% endfor %}
 
-		<!-- Body content -->
-		{% block body %}{% endblock %}
+			<!-- Body content -->
+			{% block body %}{% endblock %}
+		</div>
 
 		<!-- Include footer -->
 		{% include '_partials/footer.html.twig' %}


### PR DESCRIPTION
### Motivation

- Ensure the footer stays at the bottom of the viewport on short pages without overlapping content by converting the page to a column flex layout.

### Description

- Add CSS rules in `app/public/css/style.css` to implement a sticky footer using `html { min-height: 100%; }`, `body.site-layout { display: flex; flex-direction: column; min-height: 100vh; }`, `.site-content { flex: 1 0 auto; }`, and `body.site-layout > footer { flex-shrink: 0; }`.
- Update `app/templates/base.html.twig` to apply the `site-layout` class to the `body` and wrap main content and flash messages in a new `div` with class `site-content` so the layout flexbox can reserve space for the footer.
- Preserve existing includes for navbar, footer, scripts, and chatbot while shifting content and flash message placement inside the new wrapper.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5e302b301483219dfcea2067e0f391)