### PR TITLE
Remplacer « Digital Consulting » par « ♿ Handi-3D » dans la navigation

### DIFF
--- a/app/templates/_partials/navbar.html.twig
+++ b/app/templates/_partials/navbar.html.twig
@@ -140,16 +140,16 @@
                     </li>
 
                     <li class="nav-item" role="none">
-                        <a class="nav-link text-light {{ app.request.attributes.get('_route') == 'app_digital_consulting' ? 'active' : '' }}"
-                           href="{{ path('app_digital_consulting') }}"
+                        <a class="nav-link text-light {{ app.request.attributes.get('_route') == 'handi_3d_index' ? 'active' : '' }}"
+                           href="{{ path('handi_3d_index') }}"
                            role="menuitem"
-                           {% if app.request.attributes.get('_route') == 'app_digital_consulting' %}
+                           {% if app.request.attributes.get('_route') == 'handi_3d_index' %}
                                aria-current="page"
-                               aria-label="Digital Consulting - Page courante"
+                               aria-label="Handi-3D - Page courante"
                            {% else %}
-                               aria-label="Services de conseil en transformation numérique"
+                               aria-label="Découvrir Handi-3D, notre espace virtuel inclusif"
                            {% endif %}>
-                            Digital Consulting
+                            ♿ Handi-3D
                         </a>
                     </li>
 


### PR DESCRIPTION
### Motivation
- Remplacer le lien de la barre de navigation pointant vers la page « Digital Consulting » par le lien vers la présentation Handi-3D afin de promouvoir l’espace inclusif Handi-3D.

### Description
- Mise à jour du template `app/templates/_partials/navbar.html.twig` pour pointer vers la route `handi_3d_index`, modifier l’état actif et remplacer le texte et les libellés d’accessibilité par « ♿ Handi-3D ». 

### Testing
- Exécution de `git diff --check` et vérification du diff pour s’assurer qu’il n’y a pas d’erreurs de formatage; la vérification a réussi. 
- Tentative de lint Twig avec `php bin/console lint:twig templates/_partials/navbar.html.twig` qui n’a pas pu s’exécuter complètement car les dépendances Composer ne sont pas installées dans l’environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b81bb0c8c832185869c3fc31b9464)