### PR TITLE
Ajouter page de confirmation newsletter (redirection Mailjet)

### DIFF
--- a/app/src/Controller/NewsletterConfirmationController.php
+++ b/app/src/Controller/NewsletterConfirmationController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class NewsletterConfirmationController extends AbstractController
+{
+    #[Route('/newsletter/confirmation', name: 'app_newsletter_confirmation', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('newsletter/confirmation.html.twig');
+    }
+}

--- a/app/templates/newsletter/confirmation.html.twig
+++ b/app/templates/newsletter/confirmation.html.twig
@@ -134,7 +134,7 @@
 		<section class="newsletter-confirmation__card" aria-labelledby="newsletter-confirmation-title">
 			<img class="newsletter-confirmation__logo" src="{{ asset('images/logo_trans_Gnut_06.svg') }}" alt="GNUT 06">
 			<div class="newsletter-confirmation__icon" aria-hidden="true">✓</div>
-			<h1 id="newsletter-confirmation-title">Votre inscription est confirmée&nbsp;!</h1>
+			<h1 id="newsletter-confirmation-title">Votre inscription est confirmée !</h1>
 			<p class="newsletter-confirmation__lead">
 				Merci de rejoindre la newsletter de GNUT 06. Vous recevrez bientôt nos actualités,
 				nos projets et les prochains rendez-vous de l’association.

--- a/app/templates/newsletter/confirmation.html.twig
+++ b/app/templates/newsletter/confirmation.html.twig
@@ -1,0 +1,149 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Inscription confirmée à la newsletter | GNUT 06{% endblock %}
+
+{% block stylesheets %}
+	{{ parent() }}
+	<style>
+		.newsletter-confirmation {
+			position: relative;
+			display: grid;
+			min-height: 68vh;
+			place-items: center;
+			overflow: hidden;
+			padding: 4rem 1rem;
+			background:
+				radial-gradient(circle at 15% 20%, rgba(248, 108, 248, .22), transparent 30rem),
+				radial-gradient(circle at 85% 80%, rgba(100, 206, 245, .2), transparent 28rem),
+				#101017;
+		}
+
+		.newsletter-confirmation::before,
+		.newsletter-confirmation::after {
+			position: absolute;
+			width: 13rem;
+			height: 13rem;
+			border: 1px solid rgba(255, 255, 255, .13);
+			border-radius: 50%;
+			content: '';
+		}
+
+		.newsletter-confirmation::before {
+			top: -5rem;
+			right: 8%;
+		}
+
+		.newsletter-confirmation::after {
+			bottom: -7rem;
+			left: 6%;
+			width: 18rem;
+			height: 18rem;
+		}
+
+		.newsletter-confirmation__card {
+			position: relative;
+			z-index: 1;
+			width: min(100%, 48rem);
+			padding: clamp(2rem, 6vw, 4rem);
+			border: 1px solid rgba(255, 255, 255, .14);
+			border-radius: 1.5rem;
+			background: rgba(28, 28, 39, .9);
+			box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, .35);
+			color: #fff;
+			text-align: center;
+		}
+
+		.newsletter-confirmation__logo {
+			width: 6rem;
+			height: 6rem;
+			margin-bottom: 1.5rem;
+			object-fit: contain;
+		}
+
+		.newsletter-confirmation__icon {
+			display: grid;
+			width: 4.5rem;
+			height: 4.5rem;
+			margin: 0 auto 1.5rem;
+			place-items: center;
+			border-radius: 50%;
+			background: linear-gradient(135deg, #7f29ff, #f86cf8);
+			box-shadow: 0 .75rem 2rem rgba(248, 108, 248, .25);
+			font-size: 2.2rem;
+			font-weight: 700;
+		}
+
+		.newsletter-confirmation h1 {
+			margin-bottom: 1rem;
+			color: #fff;
+			font-size: clamp(2rem, 5vw, 3.25rem);
+			line-height: 1.1;
+		}
+
+		.newsletter-confirmation__lead {
+			max-width: 37rem;
+			margin: 0 auto 1rem;
+			color: #f3f3f6;
+			font-size: clamp(1.05rem, 2vw, 1.3rem);
+			line-height: 1.65;
+		}
+
+		.newsletter-confirmation__note {
+			margin-bottom: 2rem;
+			color: #c9c9d2;
+			font-size: 1rem;
+		}
+
+		.newsletter-confirmation__button {
+			display: inline-flex;
+			align-items: center;
+			gap: .65rem;
+			min-height: 3.25rem;
+			padding: .8rem 1.5rem;
+			border: 2px solid transparent;
+			border-radius: 999px;
+			background: linear-gradient(135deg, #7f29ff, #d94ed9);
+			box-shadow: 0 .6rem 1.5rem rgba(127, 41, 255, .28);
+			color: #fff;
+			font-weight: 700;
+			text-decoration: none;
+			transition: transform .2s ease, box-shadow .2s ease;
+		}
+
+		.newsletter-confirmation__button:hover {
+			transform: translateY(-2px);
+			box-shadow: 0 .8rem 1.8rem rgba(127, 41, 255, .4);
+			color: #fff;
+		}
+
+		.newsletter-confirmation__button:focus-visible {
+			outline: 3px solid #64cef5;
+			outline-offset: 4px;
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.newsletter-confirmation__button {
+				transition: none;
+			}
+		}
+	</style>
+{% endblock %}
+
+{% block body %}
+	<main class="newsletter-confirmation" id="main-content">
+		<section class="newsletter-confirmation__card" aria-labelledby="newsletter-confirmation-title">
+			<img class="newsletter-confirmation__logo" src="{{ asset('images/logo_trans_Gnut_06.svg') }}" alt="GNUT 06">
+			<div class="newsletter-confirmation__icon" aria-hidden="true">✓</div>
+			<h1 id="newsletter-confirmation-title">Votre inscription est confirmée&nbsp;!</h1>
+			<p class="newsletter-confirmation__lead">
+				Merci de rejoindre la newsletter de GNUT 06. Vous recevrez bientôt nos actualités,
+				nos projets et les prochains rendez-vous de l’association.
+			</p>
+			<p class="newsletter-confirmation__note">À très vite dans votre boîte de réception.</p>
+			<a class="newsletter-confirmation__button" href="{{ path('app_home') }}">
+				<span aria-hidden="true">←</span>
+				Retour à l’accueil
+			</a>
+		</section>
+	</main>
+{% endblock %}

--- a/app/tests/Functional/PublicRouteSmokeTest.php
+++ b/app/tests/Functional/PublicRouteSmokeTest.php
@@ -39,6 +39,7 @@ class PublicRouteSmokeTest extends WebTestCase
         yield 'Reset password request' => ['/reset-password'];
         yield 'TIH Search' => ['/tih/tih_search'];
         yield 'Digital consulting' => ['/digital/consulting'];
+        yield 'Newsletter confirmation' => ['/newsletter/confirmation'];
     }
 
     /**
@@ -69,6 +70,15 @@ class PublicRouteSmokeTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
         $this->assertSelectorExists('html');
+    }
+
+    public function testNewsletterConfirmationPageHasConfirmationAndHomeLink(): void
+    {
+        $this->client->request('GET', '/newsletter/confirmation');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Votre inscription est confirmée !');
+        $this->assertSelectorExists('a[href="/"]');
     }
 
     public function testLoginPageHasForm(): void


### PR DESCRIPTION
### Motivation

- Fournir une URL de redirection publique pour la confirmation du double opt‑in Mailjet afin que les abonnés soient redirigés vers une page dédiée après validation par e‑mail.
- Afficher un message clair et accessible confirmant l’inscription et proposer un bouton pour retourner à l’accueil du site.

### Description

- Ajout d’un contrôleur public `NewsletterConfirmationController` exposant la route `GET /newsletter/confirmation` (fichier `app/src/Controller/NewsletterConfirmationController.php`).
- Création d’un template Twig `newsletter/confirmation.html.twig` avec un design responsive, styles intégrés accessibles et logo GNUT 06, incluant un bouton « Retour à l’accueil » pointant vers la route principale (fichier `app/templates/newsletter/confirmation.html.twig`).
- Mise à jour des tests fonctionnels publics en ajoutant l’URL au provider et un test vérifiant le titre de confirmation et le lien vers l’accueil (fichier `app/tests/Functional/PublicRouteSmokeTest.php`).

### Testing

- `git diff --check` a été exécuté et n’a retourné aucune erreur.
- Vérification de la syntaxe PHP avec `php -l` sur `app/src/Controller/NewsletterConfirmationController.php` et `app/tests/Functional/PublicRouteSmokeTest.php` : aucun problème de syntaxe détecté.
- `npm run build` (assets) compilé avec succès et les bundles JS/CSS ont été générés par Webpack Encore.
- `php bin/console lint:twig` et `phpunit` n’ont pas été exécutés avec succès dans cet environnement car `composer install` a d’abord échoué pour des contraintes de plateforme (PHP 8.5 vs dépendances attendues) puis a rencontré des erreurs réseau (téléchargements dist/proxy), empêchant l’installation complète des dépendances nécessaires pour lancer la validation Twig et les tests Symfony.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6bb086fa5083218500a742b256e157)