### PR TITLE
Remplacer « Digital consulting » par « Accompagnement digital »

### DIFF
--- a/app/templates/_partials/footer.html.twig
+++ b/app/templates/_partials/footer.html.twig
@@ -146,7 +146,7 @@
 						<a href="{{ path('app_metavers') }}">Salles 3D immersives</a>
 					</li>
 					<li>
-						<a href="{{ path('app_digital_consulting') }}">Digital consulting</a>
+						<a href="{{ path('app_digital_consulting') }}">Accompagnement digital</a>
 					</li>
 					<li>
 						<a href="https://compta.gnut06.org">Gnut 06 Comptabilité</a>

--- a/app/templates/digital_consulting/index.html.twig
+++ b/app/templates/digital_consulting/index.html.twig
@@ -145,7 +145,7 @@ a:focus,
                     <header>
                         <!-- ✅ CORRECTION - H1 visible et descriptif -->
                         <h1 id="page-title" class="fw-bold mb-4">
-                            Digital Consulting
+                            Accompagnement digital
                         </h1>
                     </header>
 
@@ -187,7 +187,7 @@ a:focus,
                     <figure>
                         <img src="{{ asset('images/webp/consulting.webp') }}"
                              class="img-fluid rounded"
-                             alt="Deux personnes collaborant dans un espace numérique virtuel, illustrant le digital consulting inclusif de Gnut 06"
+                             alt="Deux personnes collaborant dans un espace numérique virtuel, illustrant l’accompagnement digital inclusif de Gnut 06"
                              role="img">
                     </figure>
                 </div>

--- a/app/tests/Functional/PublicRouteSmokeTest.php
+++ b/app/tests/Functional/PublicRouteSmokeTest.php
@@ -38,7 +38,7 @@ class PublicRouteSmokeTest extends WebTestCase
         yield 'Don casque donateur form' => ['/donateur/formulaire'];
         yield 'Reset password request' => ['/reset-password'];
         yield 'TIH Search' => ['/tih/tih_search'];
-        yield 'Digital consulting' => ['/digital/consulting'];
+        yield 'Accompagnement digital' => ['/digital/consulting'];
         yield 'Newsletter confirmation' => ['/newsletter/confirmation'];
     }
 


### PR DESCRIPTION
### Motivation
- Harmoniser le libellé public en remplaçant l’anglicisme « Digital consulting » par la formulation française « Accompagnement digital » dans l’interface et les tests.

### Description
- Remplace le texte du lien dans le pied de page dans `app/templates/_partials/footer.html.twig` par `Accompagnement digital`.
- Met à jour le titre principal et le texte alternatif de l’illustration dans `app/templates/digital_consulting/index.html.twig` pour utiliser la nouvelle formulation.
- Adapte le libellé fourni par le data provider du test fonctionnel dans `app/tests/Functional/PublicRouteSmokeTest.php` pour refléter le changement d’intitulé.

### Testing
- Exécution de la recherche pour l’occurrence : `rg -n -i "Digital consulting" . --glob '!vendor/**' --glob '!node_modules/**'` et aucune occurrence restante a été trouvée.
- Vérification du diff : `git diff --check` n’a retourné aucune erreur de formatage.
- Tentative d’exécution du test ciblé : `php bin/phpunit tests/Functional/PublicRouteSmokeTest.php` n’a pas pu être lancée car le script `vendor/symfony/phpunit-bridge/bin/simple-phpunit.php` est absent de l’environnement, donc les tests PHPUnit n’ont pas été exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6bc40109588321836518c81cb5d4c9)